### PR TITLE
Remove "Intermediate" slide option remove until content becomes available

### DIFF
--- a/_stylesheets/materials.css
+++ b/_stylesheets/materials.css
@@ -159,10 +159,15 @@ section {
     -webkit-transition: background 250ms ease-in-out; }
     .tab-panel label:hover {
       background: #fff; }
+  .tab-panel .column-2up {
+    width: 50%; }
+  .tab-panel .column-3up {
+    width: 33%; }
+  .tab-panel .column-4up {
+    width: 25%; }
   .tab-panel .tab {
     float: left;
-    width: 118px;
-    border: solid 1px #dfdfdf; }
+    box-shadow: 0 0 0 1px #dfdfdf; }
     .tab-panel .tab.first {
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px;

--- a/_stylesheets/materials.scss
+++ b/_stylesheets/materials.scss
@@ -195,10 +195,19 @@ section{
 		}
 	}
 
+	.column-2up{
+		width: 50%;
+	}
+	.column-3up{
+		width: 33%;
+	}
+	.column-4up{
+		width: 25%;
+	}
+
 	.tab{
 		float: left;
-		width: 118px;
-		border: solid 1px #dfdfdf;
+		box-shadow: 0 0 0 1px #dfdfdf;
 
 		&.first{
 			border-top-left-radius: 5px;

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ description: Open source materials for teaching GitHub and Git skills.
 
       <div class="tab-panel">
         <input type="radio" class="material-type" name="material-list" id="material-foundations" value="Foundations" checked="checked">
-        <label class="tab first" for="material-foundations">
+        <label class="tab column-2up first" for="material-foundations">
           <span>Foundations</span>
 
           <div class="panel-content">
@@ -47,23 +47,8 @@ description: Open source materials for teaching GitHub and Git skills.
           </div>
         </label>
 
-        <input type="radio" class="material-type" name="material-list" id="material-intermediate" value="Intermediate">
-        <label class="tab" for="material-intermediate">
-          <span>Intermediate</span>
-
-          <div class="panel-content">
-            <p>Discover useful shortcuts and option switches and more advanced GitHub features.</p>
-
-            <ul>
-              <li><span class="octicon-hero"><span class="octicon octicon-file-text"></span></span><a href="outlines/github-intermediate.html">Outline</a></li>
-              <li><span class="octicon-hero"><span class="octicon octicon-megaphone"></span></span><a href="slides/github-intermediate.html">Slides</a></li>
-              <li><span class="octicon-hero"><span class="octicon octicon-book"></span></span><a href="cheatsheets/github-intermediate.html">Cheatsheet</a></li>
-            </ul>
-          </div>
-        </label>
-
         <input type="radio" class="material-type" name="material-list" id="material-advanced" value="Advanced">
-        <label class="tab last" for="material-advanced">
+        <label class="tab column-2up last" for="material-advanced">
           <span>Advanced</span>
 
           <div class="panel-content">


### PR DESCRIPTION
Update menu for content selection "level" to not include "Intermediate" as content has not yet been developed.

![screen shot 2014-01-09 at 6 30 18 pm](https://f.cloud.github.com/assets/352082/1884162/ec998e96-7996-11e3-88af-ba0735acdae1.png)
