### PR TITLE
Typos on Foundations cheat sheet, make use of example.com

### DIFF
--- a/cheatsheets/github-foundations.md
+++ b/cheatsheets/github-foundations.md
@@ -7,7 +7,7 @@ description: A quick reference to commands use in the GitHub Foundations class.
 This quick reference guide will be your companion for the outline and slides of the GitHub Foundations class taught by the [GitHub Training Team](http://training.github.com/) and other educational groups.
 
 ## Conventions
-* `<variable>` is value you replace
+* `<variable>` should be replaced with an appropriate value or text
 * `$` is your command prompt
 * Indented lines after the `$` line are the command's expected response
 * `#` is a comment within the command example
@@ -15,16 +15,16 @@ This quick reference guide will be your companion for the outline and slides of 
 ## The Commands
 
 ###  Git
-Git is an open source distributed version control system invented by Linus Torvals in 2005.  It is used to version the Linux kernel and is shown to be, by some research, the most popular modern version control system.
+Git is an open source distributed version control system invented by Linus Torvalds in 2005.  It is used to version the Linux kernel and is shown to be, by some research, the most popular modern version control system.
 
 ###  GitHub
 GitHub is a Git repository hosting and code collaboration platform for both open source and private projects.
 
 ###  A Brief Tour of Git
-Git has a unique twist on version control in which each _cloned_ copy of the repository contains all branches, tags, and commits ever saved to the project. This provides local-disk speed for almost any operation. Network operations are performed in batch and compressed before sending, thus making over-the-wire operations seem incredible fast.
+Git has a unique twist on version control in which each _cloned_ copy of the repository contains all branches, tags, and commits ever saved to the project. This provides local-disk speed for almost any operation. Network operations are performed in batch and compressed before sending, thus making over-the-wire operations seem incredibly fast.
 
 ## Setup
-Only two areas of setup are required to complete this course: A Git installation and free GitHub account.
+Only two areas of setup are required to complete this course: A Git installation and a free GitHub account.
 
 ###  GitHub Account
 GitHub accounts are free. Sign up for one at https://github.com/join.
@@ -37,7 +37,7 @@ Git can be installed as a unified GitHub GUI and command line or merely via a st
 * **Linux**: Git's source code and a listing of supported package managers can be found at http://git-scm.com/download/linux.
 
 ###  Git version
-Verifying that Git is installed and operational can be done by requesting Git to display it's current version using this command:
+Verifying that Git is installed and operational can be done by requesting Git to display its current version using this command:
 
 ```
 $ git --version
@@ -47,7 +47,7 @@ $ git --version
 Git's configuration is saved in one of three plain text files and is easily editable with a text editor and portable to other machines by copying the configuration files.
 
 ### User information
-Your name and email address are configured locally in Git and are attached to each commit. Set these accurate to receive proper attributino for your work.
+Your name and email address are configured locally in Git and are attached to each commit. Set these accurately to receive proper attribution for your work.
 
 To inspect the current settings, individually query two configuration values:
 
@@ -56,14 +56,14 @@ $ git config user.name
   Firstname Lastname
 
 $ git config user.email
-  someaccount@somedomain.com
+  someaccount@example.com
 ```
 
 To set the same values to apply to any of your repositories:
 
 ```
 $ git config --global user.name "<Firstname Lastname>"
-$ git config --global user.email "<someaccount@somedomain.com>"
+$ git config --global user.email "<someaccount@example.com>"
 ```
 
 ### Scopes
@@ -108,7 +108,7 @@ Create a repository in the current directory of an existing project:
 git init
 ```
 
-### Repository from existing dir
+### Repository from existing directory
 Create a repository in a brand new subdirectory:
 ```
 git init <projectname>


### PR DESCRIPTION
Note about <variable> seemed a bit clunky reading-wise.

GitHub accounts are free, but clauses mentioning such are too close together. Leave "Setup" to describe what's needed, and keep the free part in the section that follows right after.

Torvalds was misspelt.

Prefer use of example.com since the other is real, parked.
