### PR TITLE
Remove dangling SPAN tags from Foundations workbook

### DIFF
--- a/workbooks/github-foundations.md
+++ b/workbooks/github-foundations.md
@@ -1,7 +1,7 @@
 ---
 layout: workbook
 title: Foundations Workbook
-description: This workbook will be your companion for the slides of the GitHub Foundations class taught by the [GitHub Training Team](http://training.github.com/) and other educational groups. In this GitHub Training course, you'll learn all the necessary skills to be productive with Git and GitHub in your open source work or daily job assignments.
+description: This workbook will be your companion for the slides of the GitHub Foundations class taught by the [GitHub Training Team](http://training.github.com/) and other educational groups. In this GitHub Training course, you'll learn all the necessary skills to be productive with GitHub and Git in your open source work or daily job assignments.
 ---
 
 ##  Git <a href="http://git-scm.com/book/en/Getting-Started-A-Short-History-of-Git" class="booklink">Pro Git Book: The History of Git</a>


### PR DESCRIPTION
Git install advice feels like it needs the "interface" to end the sentence otherwise it just drops off.

Don't see where the opening `<span>` tags are, so hopefully this isn't hobbling it if it's included elsewhere.
