### PR TITLE
Update Training logo links to main site

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,7 +1,7 @@
 <section class="colorful">
 	<nav>
 		<hgroup>
-			<a href="../">
+			<a href="https://training.github.com">
 				<span class="mega-octicon octicon-logo-github"></span>
 				<span class="logo-training"></span>
 			</a>

--- a/_stylesheets/home.css
+++ b/_stylesheets/home.css
@@ -11,6 +11,8 @@ section {
     padding: 20px 0 0 0; }
     section .hero hgroup {
       margin-top: 60px; }
+    section .hero a {
+      text-decoration: none; }
     section .hero p {
       font-size: 112.5%;
       color: #0d3f6b;

--- a/_stylesheets/home.scss
+++ b/_stylesheets/home.scss
@@ -19,6 +19,10 @@ section{
       margin-top: 60px;
     }
 
+    a{
+      text-decoration: none;
+    }
+
     p{
       font-size: 112.5%;
       color: darken($color-dark, 20%);

--- a/index.html
+++ b/index.html
@@ -7,8 +7,10 @@ description: Open source materials for teaching GitHub and Git skills.
 
 <section class="colorful see-thru navigation" id="floating-nav">
   <nav>
-    <span class="mega-octicon octicon-logo-github"></span>
-    <span class="logo-training"></span>
+    <a href="https://training.github.com">
+      <span class="mega-octicon octicon-logo-github"></span>
+      <span class="logo-training"></span>
+    </a>
     <ul>
       <li><a href="#slides">Slides</a></li>
       <li><a href="#workbook">Workbook</a></li>
@@ -20,9 +22,11 @@ description: Open source materials for teaching GitHub and Git skills.
 
 <section class="colorful figures">
   <div class="container center hero">
-    <span class="mega-octicon octicon-logo-github"></span>
-    <span class="logo-training"></span>
-
+    <a href="https://training.github.com">
+      <span class="mega-octicon octicon-logo-github"></span>
+      <span class="logo-training"></span>
+    </a>
+    
     <hgroup>
       <div class="">
         <h1>Open source teaching resources</h1>


### PR DESCRIPTION
All GitHub Training logos now link to the https://training.github.com home page.

![screen shot 2014-03-17 at 2 37 26 pm](https://f.cloud.github.com/assets/352082/2441393/0f8cce7a-ae14-11e3-81e3-843863799103.png)
![screen shot 2014-03-17 at 2 37 39 pm](https://f.cloud.github.com/assets/352082/2441394/0f8d15c4-ae14-11e3-8009-2f0039ad11be.png)

/cc @matthewmccullough 
