### PR TITLE
Remove blank CSS classes on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@ description: Open source kit for teaching GitHub and Git skills.
   <div class="container">
     <div class="half">
       <div class="content">
-        <h2 class="">Slide decks right in your browser</h2>
-        <p class="">
+        <h2>Slide decks right in your browser</h2>
+        <p>
           We've created a slide deck for each class we offer.
           Just launch any class and teach from the web browser.
         </p>
@@ -97,7 +97,7 @@ description: Open source kit for teaching GitHub and Git skills.
       <div class="content">
         <h3>Community contributions</h3>
         <p>
-          Would you like to update or clarifiy content in the slides or workbooks?
+          Would you like to update or clarify content in the slides or workbooks?
           Just fork the repository, make your changes, and submit a Pull Request.
         </p>
         <p>


### PR DESCRIPTION
Or at least they don't seem to be placeholders for named selectors later on.
