### PR TITLE
GitHub Git Concepts as Markdown

### DIFF
--- a/downloads/github-git-concepts_BETA.md
+++ b/downloads/github-git-concepts_BETA.md
@@ -99,6 +99,3 @@ Retrieving changes from a shared repository and automatically merging in any new
 $ git checkout [target-branch]
 $ git pull origin [upstream-branch]
 ```
-
-## Bonus Materials
-TBD


### PR DESCRIPTION
Just as the [PR for the _Cheat Sheet_ content](https://github.com/github/training-kit/pull/66), this adds the Markdown for an as yet-to-be-completed download document for Git Concepts.

I'd welcome any feedback on the value of this document's content and if it would be useful to finish as a downloadable PDF.

Screenshots of the original PDF layout (rough draft) included for reference of where this is headed:
![1](https://cloud.githubusercontent.com/assets/352082/2802791/90fb378e-cc92-11e3-877d-a6f219f8ace9.png)
![2](https://cloud.githubusercontent.com/assets/352082/2802792/90fb8fea-cc92-11e3-9325-e77bae55f6fd.png)
