### PR TITLE
Removed non-ascii, '&' in file is troublesome\!

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
     </a>
 
     <ul class="site-footer-links">
-      <li>&copy; {{ site.time | date: '%Y' }} <span>GitHub</span>, Inc.</li>
+      <li>&copy; {{ site.time | date: '%Y' }} <span>GitHub</span>, Inc.</li>
       <li><a href="https://github.com/site/terms">Terms</a></li>
       <li><a href="https://github.com/site/privacy">Privacy</a></li>
       <li><a href="https://github.com/security">Security</a></li>

--- a/_layouts/bare.html
+++ b/_layouts/bare.html
@@ -5,7 +5,7 @@
 <!DOCTYPE html>
 <html lang="{% if page.lang %}{{ page.lang }}{% else %}{{ site.lang }}{% endif %}">
   <head>
-    <title>{% if page.title %}{{ page.title }} • {% endif %}{{ site.title }}</title>
+    <title>{% if page.title %}{{ page.title }} * {% endif %}{{ site.title }}</title>
     {% if page.description %}
     <meta name="description" content="{{ page.description }}" />
     {% endif %}

--- a/license.html
+++ b/license.html
@@ -13,7 +13,7 @@ title: License & Attribution
   <div class="content">
     <pre>
       <code>
-        <a href="https://training.github.com/materials">Training Materials</a> &copy; {{ site.time | date: '%Y' }} GitHub, Inc.
+        <a href="https://training.github.com/materials">Training Materials</a> &copy; {{ site.time | date: '%Y' }} GitHub, Inc.
       </code>
     </pre>
   </div>

--- a/slides/_posts/advanced/bundle/0001-01-01-Archiving-with-Bundle.md
+++ b/slides/_posts/advanced/bundle/0001-01-01-Archiving-with-Bundle.md
@@ -22,5 +22,5 @@ Tag the last archive snapshot
 
 	git bundle create <file> <git-rev-list-args>
 	git bundle verify <file>
-	git bundle list-heads <file> [<rev>…]
-	git bundle unbundle <file> [<rev>…]
+	git bundle list-heads <file> [<rev>]
+	git bundle unbundle <file> [<rev>]

--- a/slides/_posts/advanced/remote/0001-01-01-Custom-Fetch-&-Push.md
+++ b/slides/_posts/advanced/remote/0001-01-01-Custom-Fetch-&-Push.md
@@ -5,13 +5,13 @@ tags: ['advanced/remote']
 ---
  
 	# Name Spacing Branches for Fetch
-	git config --add remote.<remote-name>.fetch ↴
-		'+refs/heads/<name-space>/*: ↴
+	git config --add remote.<remote-name>.fetch 
+		'+refs/heads/<name-space>/*: 
 			refs/remotes/<remote-name>/<name-space>/*
 
 	# Name Spacing Branches for Push
-	git config --add remote.origin.push ↴
-		'+refs/heads/<branch-name>: ↴
+	git config --add remote.origin.push 
+		'+refs/heads/<branch-name>: 
 			refs/heads/<name-space>/<branch-name>
 
 {% capture notes %}

--- a/slides/_posts/advanced/remote/0002-01-01-Fetch-Pull-Requests.md
+++ b/slides/_posts/advanced/remote/0002-01-01-Fetch-Pull-Requests.md
@@ -6,7 +6,7 @@ tags: ['advanced/remote']
  
 	# Retrieve Pull Requests
 	# Using `git config`
-	git config --add remote.origin.fetch ↴
+	git config --add remote.origin.fetch 
 		'+refs/pull/*/head:refs/remotes/origin/pull/*
 
 	# Editing .git/config with editor

--- a/slides/_posts/foundations/init/0002-01-01-Repository-from-Existing-Dir.md
+++ b/slides/_posts/foundations/init/0002-01-01-Repository-from-Existing-Dir.md
@@ -10,7 +10,7 @@ tags: ['init']
 
 	# Add all the code
 	$ git add .
-	$ git commit -m ”Initial import” 
+	$ git commit -m "Initial import"
 
 {% capture notes %}
 

--- a/slides/_posts/foundations/network/0002-01-01-Adding-a-Remote.md
+++ b/slides/_posts/foundations/network/0002-01-01-Adding-a-Remote.md
@@ -10,6 +10,6 @@ tags: ['network']
 {% capture notes %}
 * Remotes are symbolic names
 * Create as many as you like
-* Default is `origin` (if you’ve cloned)
+* Default is `origin` (if you've cloned)
 {% endcapture %}
 {% include hydeslides/core/notes %}

--- a/slides/_posts/foundations/tag/0001-01-01-Tagging-Commits.md
+++ b/slides/_posts/foundations/tag/0001-01-01-Tagging-Commits.md
@@ -14,7 +14,7 @@ tags: ['tag']
 	# List known tags
 	git tag
 
-	# Show a tag’s contents
+	# Show a tag's contents
 	git show tag
 
 	* Tag a revision

--- a/slides/_posts/foundations/tag/0003-01-01-Transmitting-Tags.md
+++ b/slides/_posts/foundations/tag/0003-01-01-Transmitting-Tags.md
@@ -16,5 +16,3 @@ Tags do fetch by default
 Tags don't push by default
 {% endcapture %}
 {% include hydeslides/core/notes %}
-
-￼￼￼

--- a/slides/github-first-look.html
+++ b/slides/github-first-look.html
@@ -2,7 +2,7 @@
 theme: github
 layout: slide
 deck_type: revealjs
-title: GitHub – A First Look
+title: GitHub - A First Look
 chapters: [
 	'preroll',
     'trainers/matthew-mccullough',


### PR DESCRIPTION
Here is a request to change the name of a file to remove the troublesome '&'
And a fix for the non-ascii characters that plagued the bring up of
`jekyll serve` on my MacBook Pro yesterday in class.

George Wood

Please change the name of
`slides/_posts/advanced/remote/0001-01-01-Custom-Fetch-&-Push.md`
to 
`slides/_posts/advanced/remote/0001-01-01-Custom-Fetch-and-Push.md`

As the `&` causes the bash shell to stop parsing at that point and push the partial command with the partial filename into the background to mess things up.

George
