### PR TITLE
Add conditional safety to `notes` field

### DIFF
--- a/_includes/hydeslides/core/notes
+++ b/_includes/hydeslides/core/notes
@@ -1,3 +1,3 @@
 <aside class="notes">
-{{ notes | markdownify }}
+{% if notes %}{{ notes | markdownify }}{% endif %}
 </aside>


### PR DESCRIPTION
Prevents `jekyll build` from failing.
