### PR TITLE
Fine tune slide title styling

### DIFF
--- a/slides/dependencies/themes/github/css/overrides.scss
+++ b/slides/dependencies/themes/github/css/overrides.scss
@@ -112,12 +112,13 @@ pre code{
 
 h1{
 	font-family: "Apex New", $font-default !important;
-	font-weight: bold !important;
+	font-weight: normal !important;
 	color: $brand-darkGrey !important;
-	font-size: 1.5em !important;
-	display: inline !important;
+	font-size: .8em !important;
+	// display: inline !important;
 	line-height: 2em !important;
 	text-align: center;
+	display: block !important;
 }
 	.cover h1{
 		display: block;

--- a/slides/dependencies/themes/github/css/theme.css
+++ b/slides/dependencies/themes/github/css/theme.css
@@ -1,12 +1,12 @@
-@import url(revealjs.css);
-@import url(octicons.css);
 /*
   Custom variant to avoid font-overrides
   when using Octicons
 */
+@import url(revealjs.css);
 /*
   Octicons
 */
+@import url(octicons.css);
 /*
   Overrides, Design, Theme
 */
@@ -109,12 +109,12 @@ pre code {
 
 h1 {
   font-family: "Apex New", "Helvetica Neue", Helvetica !important;
-  font-weight: bold !important;
+  font-weight: normal !important;
   color: #333333 !important;
-  font-size: 1.5em !important;
-  display: inline !important;
+  font-size: .8em !important;
   line-height: 2em !important;
-  text-align: center; }
+  text-align: center;
+  display: block !important; }
 
 .cover h1 {
   display: block;


### PR DESCRIPTION
Cleans up the overly bold headings of the chapter covers and the `h1` and `h2` titles of slides.

![screen shot 2014-06-02 at 11 20 20 pm](https://cloud.githubusercontent.com/assets/352082/3148484/2be39d9a-ea61-11e3-9813-636b9dc9e86c.png)
![screen shot 2014-06-02 at 11 20 22 pm](https://cloud.githubusercontent.com/assets/352082/3148486/2beb6e9e-ea61-11e3-8645-37db6d7109e4.png)
