### PR TITLE
Restore Foundations deck, tune chapers

### DIFF
--- a/slides/github-foundations.md
+++ b/slides/github-foundations.md
@@ -1,0 +1,17 @@
+---
+layout: slide
+deck_type: revealjs
+theme: github
+title: GitHub Foundations Course Slides
+description: A slide deck to the GitHub Foundations class.
+chapters: [
+  'preroll',
+  'version-control',
+  'commit-basics',
+  'branch-basics',
+  'tag-basics',
+  'github/pull-requests',
+  'github/contributors',
+  'github/organizations',
+  'goodbye']
+---


### PR DESCRIPTION
This brings `github-foundations.md` back after accidental removal in 5a0cb20 and includes additional foundational slide chapters.

Actual slides still need further refinement, but eliminates the 404 of the Kit home page's link to the [Foundations deck](https://training.github.com/kit/github-foundations.html).
