### PR TITLE
Fixed mixed content warning when loading jquery without SSL

### DIFF
--- a/_layouts/bare.html
+++ b/_layouts/bare.html
@@ -35,10 +35,11 @@
 
     {% include analytics.html %}
 
-    <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
     {% if page.theme == "home" %}
+      <script src="_javascript/jquery-1.11.0.min.js"></script>
       <script src="_javascript/page.js"></script>
     {% else %}
+      <script src="../_javascript/jquery-1.11.0.min.js"></script>
       <script src="../_javascript/page.js"></script>
     {% endif %}
   </head>


### PR DESCRIPTION
Loading https://training.github.com/kit/ results in a mixed content warning and blocks jQuery:

![screen shot 2014-06-16 at 9 36 23 am](https://cloud.githubusercontent.com/assets/1060/3284848/6a90d726-f531-11e3-9e6a-a96e49f86b30.png)

This PR uses the jquery available in `_javascripts` instead, avoid that issue entirely.

cc @jordanmccullough @matthewmccullough
