### PR TITLE
Add missing "log" statement to examples

### DIFF
--- a/slides/_posts/intermediate/reviewing-changes/0003-01-01-filtering.md
+++ b/slides/_posts/intermediate/reviewing-changes/0003-01-01-filtering.md
@@ -12,7 +12,7 @@ $ git log -[n]
 ```
 
 ```bash
-$ git --author [author-name]
-$ git -S [string-in-patch]
-$ git -G [regex-matching-commit-message]
+$ git log --author [author-name]
+$ git log -S [string-in-patch]
+$ git log -G [regex-matching-commit-message]
 ```


### PR DESCRIPTION
The examples were missing the "log" keyword. Added them.
