### PR TITLE
Proper cap on GitHub Pages

### DIFF
--- a/slides/index.md
+++ b/slides/index.md
@@ -25,7 +25,7 @@ showinnav: true
 <section>
 <p>
 <a href="github-pages.html">GitHub Pages</a></br>
-  <em>Thorough coverage of what GitHub pages are and how to get started using them</em>
+  <em>Thorough coverage of what GitHub Pages are and how to get started using them</em>
 </p>
 </section>
 


### PR DESCRIPTION
Pretty sure the GitHub Pages slides aren't being taught from this Kit since it's not directly linked unless you happen to URL upverse, so this could be just not merged all the same. 

Just a minor brand pickup on the "GitHub Pages".
