### PR TITLE
Add support for full relative patching of curriculum

### DIFF
--- a/_layouts/curriculum.html
+++ b/_layouts/curriculum.html
@@ -1,9 +1,10 @@
 ---
 layout: bare
+leadingpath: ../
 ---
 
-<script src="../_javascript/snap-svg/dist/snap.svg-min.js"></script>
-<script src="../_javascript/curriculum.js"></script>
+<script src="{{ page.leadingpath }}_javascript/snap-svg/dist/snap.svg-min.js"></script>
+<script src="{{ page.leadingpath }}_javascript/curriculum.js"></script>
 
 <section class="hero overview">
   <div class="container">


### PR DESCRIPTION
Follows from #202 for support of dark shipped materials and applies same fix
to live curriculum pages.
