### PR TITLE
Remove Resources nav link

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -19,7 +19,6 @@
 						<li><a{% if page.body_class == 'classes' %} class="active"{% endif %} href="{{ site.url }}/classes/">Classes</a></li>
 						<li><a{% if page.body_class == 'schedule' %} class="active"{% endif %} href="{{ site.url }}/schedule/">Schedule</a></li>
 						<li><a class="active" href="{{ site.url }}/kit/">Kit</a></li>
-						<li><a{% if page.body_class == 'resources' %} class="active"{% endif %}  href="{{ site.url }}/resources/">Resources</a></li>
 						<li><a{% if page.body_class == 'contact' %} class="active"{% endif %} href="{{ site.url }}/contact/">Contact</a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
Taking access to existing Resources pages dark in favor of the embedded
videos, links, and workbook-like information directly embedded in the
Foundations, Intermediate, and Advanced pages.
