### PR TITLE
Fixes #261 by updating the link to `github`

### DIFF
--- a/slides/index.md
+++ b/slides/index.md
@@ -10,7 +10,7 @@ showinnav: true
 
 <section>
 <p>
-<a href="git-foundations.html">Git Foundations</a></br>
+<a href="github-foundations.html">GitHub Foundations</a></br>
   <em>A thorough course on GitHub and Git used in GitHub:Training classrooms</em>
 </p>
 </section>
@@ -31,7 +31,7 @@ showinnav: true
 
 <section>
 <p>
-<a href="github-advanced.html">Git Advanced</a></br>
+<a href="github-advanced.html">GitHub Advanced</a></br>
   <em>Advanced Git techniques for the experienced Git user</em>
 </p>
 </section>


### PR DESCRIPTION
- Was previously `git` for foundations slides link
- Also updated Advanced class page text to GitHub instead of just Git since the focus has expanded to include the platform, not just the CLI tool
