### PR TITLE
Enable TOC "open" by default

### DIFF
--- a/_layouts/curriculum.html
+++ b/_layouts/curriculum.html
@@ -20,14 +20,14 @@ leadingpath: ../
 
 
 <div id="toc-toggle">
-  <input type="checkbox" class="toc-toggle-check" id="toc-toggle-check" name="toc-toggle-check" value="true">
+  <input type="checkbox" class="toc-toggle-check" id="toc-toggle-check" name="toc-toggle-check" value="true" checked="checked">
   <label class="toc-toggle-label" for="toc-toggle-check">
     <span class="octicon octicon-list-unordered"></span>
     <!-- <span class="toc-header">Table of Contents</span> -->
   </label>
 </div>
 
-<div class="col-content deck  col-md-12 col-sm-12 col-xs-12 materials curriculum">
+<div class="col-content deck  col-md-12 col-sm-12 col-xs-12 materials curriculum shift-left">
   <div id="teacher" class="hidden">
     <div class="alignment">
       <div id="teacher-avatar" class=""></div>
@@ -71,7 +71,7 @@ leadingpath: ../
 </div>
 
 
-<div class="col-toc col-md-2 col-sm-2 col-xs-2">
+<div class="col-toc col-md-2 col-sm-2 col-xs-2 shift-left">
   <div id="toc-wrapper">
     <div id="toc" data-spy="affix" data-offset-top="145">
       <ul id="toc-list" class="nav nav-pills nav-stacked" role="tablist">


### PR DESCRIPTION
Suggested via https://github.com/github/training-kit/issues/263, this provides the TOC open/on by default.

![screen shot 2014-11-09 at 7 10 14 pm](https://cloud.githubusercontent.com/assets/352082/4970323/baf434cc-687e-11e4-96b0-b55d0155362e.png)
