### PR TITLE
Remove script for building SASS compiled styles

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ task :clean do
 end
 
 task :test do
-  sh 'bundle exec sass --style compressed _stylesheets/page.scss:_stylesheets/page.css'
   sh 'bundle exec jekyll build'
 
 #  HTML::Proofer.new("./_site").run


### PR DESCRIPTION
Now relying entirely on the SASS building power of JekyllRB, so running `sass` in the Rake is no longer needed.
