### PR TITLE
Update logo style to retina-ready

### DIFF
--- a/_stylesheets/page.scss
+++ b/_stylesheets/page.scss
@@ -154,7 +154,8 @@ header{
 		width: 185px;
 		text-indent: -999px;
 		overflow: hidden;
-		background: url('../images/gh-training-logo-1x.png') no-repeat center center;
+		background: url('../images/gh-training-logo-2x.png') no-repeat center center;
+		background-size: contain;
 	}
 }
 


### PR DESCRIPTION
Aligns with fix in https://github.com/github/training-web/pull/262.
