### PR TITLE
Fixed top alignment issue

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -33,7 +33,7 @@
 
 		{% if page.body_class == "home" %}
 			<div class="jumbotron colorful classes">
-				<div class="container text-center">
+				<div class="text-center">
 
 					<div class="row">
 						<div class="col-md-4">


### PR DESCRIPTION
The 3 boxes at the top of the page aren't aligned with the rest of the grid. 

This removes the container so it doesn't break outside the already set container :smiley: 
