### PR TITLE
Git cheat sheet web-layout mimicking print

### DIFF
--- a/_stylesheets/page.scss
+++ b/_stylesheets/page.scss
@@ -190,32 +190,3 @@ footer {
 		}
 	}
 }
-
-
-.cheat-sheet{
-	-webkit-column-count: 2;
-	-moz-column-count: 2;
-	column-count: 2;
-
-	-webkit-column-gap: 4em;
-  -moz-column-gap: 4em;
-  column-gap: 4em;
-
-	h1, h1+p{
-		display: none;
-	}
-
-	h2:first-of-type{
-		margin-top: 0;
-	}
-
-	h2:last-of-type{
-		-webkit-column-span: all;
-		-moz-column-span: all;
-		column-span: all;
-
-		padding-top: 1em;
-		margin-top: 1em;
-		border-top: solid 1px $mono-light;
-	}
-}

--- a/downloads/github-git-cheat-sheet.md
+++ b/downloads/github-git-cheat-sheet.md
@@ -5,10 +5,7 @@ byline: Git is the open source distributed version control system that facilitat
 leadingpath: ../
 ---
 
-# GitHub Git Cheat Sheet
-
-Git is the open source distributed version control system that facilitates GitHub activities on your laptop or desktop. This cheat sheet summarizes commonly used Git command line instructions for quick reference.
-
+{% capture colOne %}
 ## Install Git
 GitHub provides desktop clients that include a graphical user interface for the most common repository actions and an automatically updating command line edition of Git for advanced scenarios.
 
@@ -25,7 +22,6 @@ http://git-scm.com
 
 ## Configure tooling
 Configure user information for all local repositories
-
 
 ```$ git config --global user.name "[name]"```
 
@@ -49,6 +45,14 @@ Creates a new local repository with the specified name
 ```$ git clone [url]```
 
 Downloads a project and its entire version history
+
+{% endcapture %}
+<div class="col-md-6">
+{{ colOne | markdownify }}
+</div>
+
+
+{% capture colTwo %}
 
 ## Make changes
 Review edits and craft a commit transaction
@@ -110,8 +114,15 @@ Combines the specified branch’s history into the current branch
 ```$ git branch -d [branch-name]```
 
 Deletes the specified branch
+{% endcapture %}
+<div class="col-md-6">
+{{ colTwo | markdownify }}
+</div>
+<div class="clearfix"></div>
 
+---
 
+{% capture colThree %}
 ## Refactor file names
 Relocate and remove versioned files
 
@@ -168,7 +179,12 @@ Lists all stashed changesets
 ```$ git stash drop```
 
 Discards the most recently stashed changeset
+{% endcapture %}
+<div class="col-md-6">
+{{ colThree | markdownify }}
+</div>
 
+{% capture colFour %}
 ## Review history
 Browse and inspect the evolution of project files
 
@@ -227,11 +243,7 @@ Uploads all local branch commits to GitHub
 ```$ git pull```
 
 Downloads bookmark history and incorporates changes
-
----
-
-## GitHub Training
-Learn more about using GitHub and Git. Email the Training Team or visit our website for learning event schedules and private class availability.
-
-* training@github.com
-* training.github.com
+{% endcapture %}
+<div class="col-md-6">
+{{ colFour | markdownify }}
+</div>


### PR DESCRIPTION
A first draft with minimally invasive markup in the markdown, and using common site-wide styles to mimic the [print-ready](https://training.github.com/kit/downloads/github-git-cheat-sheet.pdf) layouts of the cheat sheet.

![screen shot 2014-12-30 at 10 41 38 pm](https://cloud.githubusercontent.com/assets/352082/5585771/085ae0d0-9075-11e4-985e-099a858283d8.png)