### PR TITLE
Nest Octicon customization for slides only

### DIFF
--- a/_stylesheets/curriculum.scss
+++ b/_stylesheets/curriculum.scss
@@ -50,23 +50,6 @@ table{
 	}
 }
 
-// Custom Octicon styling
-.mega-octicon{
-	font-size: 110px;
-	color: $brand-primary;
-
-	&:after{
-		content: "";
-		display: block;
-		width: 170px;
-		height: 170px;
-		border: solid 1px $gray-light;
-		border-radius: 50%;
-		padding: 20px;
-		margin-top: -142px;
-	}
-}
-
 // Table of contents
 #toc-wrapper{
 	opacity: .5;
@@ -232,6 +215,23 @@ table{
 		p,ul{
 			font-size: 20px;
 			color: $gray;
+		}
+
+		// Custom Octicon styling
+		.mega-octicon{
+			font-size: 110px;
+			color: $brand-primary;
+
+			&:after{
+				content: "";
+				display: block;
+				width: 170px;
+				height: 170px;
+				border: solid 1px $gray-light;
+				border-radius: 50%;
+				padding: 20px;
+				margin-top: -142px;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes "oops" of specialized style for Octions on slides applying side-wide.

![screen shot 2014-12-30 at 10 50 50 pm](https://cloud.githubusercontent.com/assets/352082/5585809/5b8c82e4-9076-11e4-8a63-3dd9a028109f.png)
