### PR TITLE
Bug fix for slide, slide-only modes

### DIFF
--- a/_javascript/curriculum.js
+++ b/_javascript/curriculum.js
@@ -21,7 +21,7 @@ $(function(){
 			url: "https://api.github.com/users/"+username,
 			success: function(data, textStatus, jqXHR){
 				$("#teacher-name").html(data.name);
-				
+
 				$("<span/>",
 				{
 					text: data.login
@@ -130,7 +130,7 @@ $(function(){
 				even = $("hr:even");
 
 		even.each(function(index){
-			$(this).nextUntil("hr").wrapAll("<div class='slide'><div class='alignment'></div>");
+			$(this).nextUntil("hr").wrapAll("<div class='slide'><div class='alignment'></div></div>");
 		});
 
 		$(".slide").css("height", h + "px");

--- a/_javascript/curriculum.js
+++ b/_javascript/curriculum.js
@@ -3,9 +3,7 @@ $(function(){
 
 	// Bind checkbox/label click for slide toggle
 	$("#slide-only-toggle").change(function(){
-		var checkState = $("#slide-only-toggle").attr("checked");
-		$(".materials > *").toggleClass("hidden");
-		$(".slide").toggleClass("hidden");
+		$(".materials > *").not(".slide").toggleClass("hidden");
 	});
 
 	// Parse username from querystring
@@ -86,7 +84,6 @@ $(function(){
 				}).appendTo("#teacher-following");
 
 				$("#teacher").toggleClass("hidden");
-				$("#teacher").toggleClass("slide");
 
 				updateSlideSize();
 			}

--- a/_layouts/curriculum.html
+++ b/_layouts/curriculum.html
@@ -66,9 +66,9 @@ leadingpath: ../
 </div>
 
 <div class="col-content deck  col-md-12 col-sm-12 col-xs-12 materials curriculum shift-left">
-  <div id="teacher" class="hidden">
+  <div id="teacher" class="slide hidden">
     <div class="alignment">
-      <div id="teacher-avatar" class=""></div>
+      <div id="teacher-avatar"></div>
       <div class="" id="teacher-info">
 
         <h3 id="teacher-name"></h3>


### PR DESCRIPTION
Several undocumented but outstanding JS and layout issues are resolved in this PR:

- [x] "Slide only" mode without a `?teacher=[name]` results in empty "Teacher" slide appearing
- [x] Teacher "slide" show/hide logic is overly complicated
- [x] jQuery `wrapAll` tag set is malformed