### PR TITLE
--signoff -> --gpg-sign

### DIFF
--- a/advanced/index.md
+++ b/advanced/index.md
@@ -620,7 +620,7 @@ $ git config --global user.signingkey [ID]
 
 #### Using GPG signatures on commits
 ```shell
-$ git commit --signoff
+$ git commit --gpg-sign
 # or the shorthand invocation...
 $ git commit -S
 


### PR DESCRIPTION
The `--signoff` (or `-s`) option and the `--gpg-sign` (also `-S`) are not interchangeable. We have the right short-cut (`-S`) but this slide has the wrong long option. I think it's confusing, anyway.

`--signoff` (or `-s`) does this:

```
commit c41aebe7363901aa08e8d48879063432e8617c6a
Author: Joshua Wehner <joshua.wehner@github.com>
Date:   Fri Jan 16 17:10:08 2015 -0600

    testing
    
    Signed-off-by: Joshua Wehner <joshua.wehner@github.com>
```

`--gpg-sign` (or `-S`) does this:

```
commit 78c00b1441e0b1d03ef3271eb1cf6bdec05cb5ff
gpg: Signature made Fri Jan 16 17:11:08 2015 CST using RSA key ID A20F7983
gpg: Good signature from "Joshua Wehner <joshua.wehner@github.com>"
Author: Joshua Wehner <joshua.wehner@github.com>
Date:   Fri Jan 16 17:11:08 2015 -0600

    testing
```

It might be worth re-visiting whether commit signing is a thing we should cover here (because, arguably, signing individual commits is low value, especially compared to tag signing) but that seems like a larger can of worms.