### PR TITLE
add leading path of subversion-migration

### DIFF
--- a/downloads/subversion-migration.md
+++ b/downloads/subversion-migration.md
@@ -2,6 +2,7 @@
 layout: cheat-sheet
 title: Subversion to Git Migration
 byline: When migrating from Subversion to Git, there’s a vocabulary and command set to learn, in addition to the new capabilities only afforded by Git. This cheat sheet aims to help you in your transition between the classic Subversion technology and the modern use of Git with the GitHub collaboration platform.
+leadingpath: ..
 ---
 
 {% capture migration %}


### PR DESCRIPTION
This should fix the broken css on the training-kit for https://training.github.com/kit/downloads/subversion-migration.html

cc @jordanmccullough 