### PR TITLE
send slash in leadpath on files, not in stylesheet

### DIFF
--- a/_layouts/site.html
+++ b/_layouts/site.html
@@ -6,7 +6,7 @@ layout: bare
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>{% if page.html_title %}{{ page.html_title }} • {% endif %}GitHub Training</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="stylesheet" href="{{ page.leadingpath }}/_stylesheets/page.css">
+  <link rel="stylesheet" href="{{ page.leadingpath }}_stylesheets/page.css">
 
 
   <link rel="icon" type="image/x-icon" href="/favicon.png" />

--- a/downloads/subversion-migration.md
+++ b/downloads/subversion-migration.md
@@ -2,7 +2,7 @@
 layout: cheat-sheet
 title: Subversion to Git Migration
 byline: When migrating from Subversion to Git, there’s a vocabulary and command set to learn, in addition to the new capabilities only afforded by Git. This cheat sheet aims to help you in your transition between the classic Subversion technology and the modern use of Git with the GitHub collaboration platform.
-leadingpath: ..
+leadingpath: ../
 ---
 
 {% capture migration %}


### PR DESCRIPTION
in #312 i accidentally misread what was needing to be sent to the `site` layout. This should fix it.

of course, the layout was also including an extra slash in the path for the stylesheet, but not in any of the javascript. whoops!