### PR TITLE
Add better support for paths

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ title: GitHub Training
 
 # standard jekyll configuration
 
+baseurl: /kit
 permalink: /articles/:title
 highlighter: pygments
 exclude:

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -39,7 +39,7 @@
 
             {% for course in site.courses %}
               <div class="col-md-6">
-                <a href="{{ course.url }}">
+                <a href="{{ site.baseurl }}{{ course.url }}">
                   <div class="panel">
                     {% if course.title == "GitHub for Developers" %}
                       <span class="octicon octicon-terminal"></span>

--- a/_layouts/course.html
+++ b/_layouts/course.html
@@ -28,7 +28,7 @@ layout: site
                     {% assign classy_name = site_module.url | replace: "/modules/", "" | replace: ".html", "" %}
 
                     {% if classy_name == module %}
-                      <li><a href="/modules/{{ module }}.html">{{ site_module.title }}</a></li>
+                      <li><a href="{{ site.baseurl }}/modules/{{ module }}.html">{{ site_module.title }}</a></li>
                     {% else %}
 
                     {% endif %}


### PR DESCRIPTION
This Pull Request fixes an issue that #318 introduced where links to courses and modules break when `training-kit` is served at https://training.github.com.

These changes add a `baseurl:` of `/kit` to the configuration file that Jekyll uses when generating links to courses and modules.