### PR TITLE
Fix formatting

### DIFF
--- a/_javascript/curriculum.js
+++ b/_javascript/curriculum.js
@@ -115,7 +115,11 @@ $(function(){
   document.addEventListener("keydown", shortcuts.toggle, false);
 
   // Render the TOC
-  buildToc();
+  //buildToc();
+
+  // Hide the TOC
+  $(".module-toc").hide();
+
   // Reframe slides on any window resize
   $(window).resize(function () {
     updateSlideSize();

--- a/_javascript/curriculum.js
+++ b/_javascript/curriculum.js
@@ -1,10 +1,13 @@
 $(function(){
   var timeLeftInterval = 0;
 
+  // Hide Quizzes and Polls
+  $(".quiz").hide();
+  $(".poll").hide();
+
   // Bind checkbox/label click for slide toggle
   $("#slide-only-toggle").change(function(){
     $(".materials > *").not(".slide").toggleClass("hidden");
-    $(".poll").toggleClass("hidden");
     $(".lab").toggleClass("hidden");
   });
 

--- a/_javascript/curriculum.js
+++ b/_javascript/curriculum.js
@@ -93,7 +93,6 @@ $(function(){
         // Toggle material when self-taught
 
         $("div.video").toggleClass("hidden");
-        $("div.narration-table").toggleClass("hidden");
 
         updateSlideSize();
       }

--- a/_layouts/course.html
+++ b/_layouts/course.html
@@ -28,9 +28,14 @@ layout: site
                     {% assign classy_name = site_module.url | replace: "/modules/", "" | replace: ".html", "" %}
 
                     {% if classy_name == module %}
-                      <li><a href="{{ site.baseurl }}/modules/{{ module }}.html">{{ site_module.title }}</a></li>
-                    {% else %}
+                      {% if module contains "POLL-" %}
+                        {% comment %} Do not render.  This is a poll. {% endcomment %}
+                      {% else %}
+                        <li><a href="{{ site.baseurl }}/modules/{{ module }}.html">{{ site_module.title }}</a></li>
+                      {% endif %}
 
+                    {% else %}
+                      {% comment %} Do not render.  The module titles do not match. {% endcomment %}
                     {% endif %}
 
                   {% endfor %}

--- a/_layouts/module.html
+++ b/_layouts/module.html
@@ -216,14 +216,24 @@ layout: site
 
 </div>
 
-
 <div class="col-toc col-md-2 col-sm-2 col-xs-2 shift-left">
   <div id="toc-wrapper">
     <div id="toc" data-spy="affix" data-offset-top="145">
-      <h4>Table of Contents</h4>
+
+      <div class="module-toc">
+        <h4>Table of Contents</h4>
+        <ul id="toc-list" class="nav nav-pills nav-stacked" role="tablist">
+          <li></li>
+        </ul>
+      </div>
+
+      <h4>Courses</h4>
       <ul id="toc-list" class="nav nav-pills nav-stacked" role="tablist">
-        <li></li>
+        {% for course in site.courses %}
+            <a href="{{ site.baseurl }}{{ course.url }}"><li class="headingSep">{{ course.title }}</li></a>
+        {% endfor %}
       </ul>
+
       <ul class="nav display-controls">
         <li>
           <input type="checkbox" name="slide-only" id="slide-only-toggle" class="slide-only-check" value="true">

--- a/_layouts/module.html
+++ b/_layouts/module.html
@@ -154,11 +154,7 @@ layout: site
 
             {% when 'video-slide' %}
 
-            <div class="video">
-              <iframe src="{{ item[1].video | replace: 'youtube.com/', 'youtube.com/embed/' }}" width="480" height="320"></iframe>
-            </div>
-
-            <div class="narration-table hidden">
+            <div class="narration-table">
               <table>
                 <thead>
                   <th>

--- a/_stylesheets/curriculum.scss
+++ b/_stylesheets/curriculum.scss
@@ -378,6 +378,15 @@ table{
       font: normal normal 20px octicons;
     }
   }
+
+  /* Narration Table Styling */
+  .narration-table {
+    margin: 0 6em;
+    th {
+      text-align: center;
+      font-size: 1.5em;
+    }
+  }
 }
 
 .affix-top{


### PR DESCRIPTION
This Pull Request updates the styling of the training kit with a few tweaks:

- [x] Don't render polls and quizzes
- [x] Stop rendering the TOC (for now; future plan to possibly render a deck for each section)
- [x] Don't render videos, instead show a table with a demo script
- [x] Add links at the side of each module for each class overview page 
