### PR TITLE
Improve the Git Cheat Sheet in Portuguese

### DIFF
--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -1,12 +1,12 @@
 ---
 layout: cheat-sheet
-title: Folha de Dicas de Git do GitHub
+title: Folha de Dicas de Git do GitHub (pt-BR)
 byline: Git é um sistema de controle de versão distribuído open source que facilita ações com o GitHub em seu notebook ou desktop. Esta folha de dicas resume instruções comumente usadas via linha de comando do Git para referência rápida.
 leadingpath: ../../
 ---
 
 
-# Folha de Dicas de Git do GitHub
+# Folha de Dicas de Git do GitHub (pt-BR)
 
 Git é um sistema de controle de versão distribuído open source que facilita ações com o GitHub em seu notebook ou desktop. Esta folha de dicas resume instruções comumente usadas via linha de comando do Git para referência rápida.
 

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -131,7 +131,7 @@ Remove o arquivo do controle de versão mas preserva o arquivo localmente
 
 Muda o nome do arquivo e o prepara para o commit
 
-## Suprima o rastreamento
+## Suprima o monitoramento
 Ignore arquivos e diretórios temporários
 
 ```
@@ -153,7 +153,7 @@ Arquive e restaure mudanças incompletas
 
 ```$ git stash```
 
-Armazena temporariamente todos os arquivos rastreados modificados
+Armazena temporariamente todos os arquivos monitorados modificados
 
 
 ```$ git stash pop```

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -62,7 +62,7 @@ Lista todos os arquivos novos ou modificados para serem commitados
 
 ```$ git diff```
 
-Mostra diferenças no arquivo que não foram realizadas
+Mostra diferenças no arquivo que não foram preparadas
 
 
 ```$ git add [arquivo]```
@@ -72,12 +72,12 @@ Faz o snapshot de um arquivo na preparação para versionamento
 
 ```$ git diff --staged```
 
-Mostra a diferença entre arquivos selecionados e a suas últimas versões
+Mostra a diferença entre arquivos preparados e a suas últimas versões
 
 
 ```$ git reset [arquivo]```
 
-Deseleciona o arquivo, mas preserva seu conteúdo
+Retira o arquivo da área de preparação, mas preserva seu conteúdo
 
 
 ```$ git commit -m "[mensagem descritiva]"```
@@ -119,7 +119,7 @@ Mude e remova os arquivos versionados
 
 ```$ git rm [arquivo]```
 
-Remove o arquivo do diretório de trabalho e o seleciona para remoção
+Remove o arquivo do diretório de trabalho e o prepara a remoção
 
 
 ```$ git rm --cached [arquivo]```
@@ -129,7 +129,7 @@ Remove o arquivo do controle de versão mas preserva o arquivo localmente
 
 ```$ git mv [arquivo-original] [arquivo-renomeado]```
 
-Muda o nome do arquivo e o seleciona para o commit
+Muda o nome do arquivo e o prepara para o commit
 
 ## Suprima o rastreamento
 Ignore arquivos e diretórios temporários

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -44,7 +44,7 @@ Inicie um novo repositório ou obtenha de uma URL existente
 
 ```$ git init [nome-do-projeto]```
 
-Cria um novo repositório local com um nome específico
+Cria um novo repositório local com um nome especificado
 
 
 ```$ git clone [url]```
@@ -100,17 +100,17 @@ Cria um novo branch
 
 ```$ git checkout [nome-do-branch]```
 
-Muda para o branch específico e atualiza o diretório de trabalho
+Muda para o branch especificado e atualiza o diretório de trabalho
 
 
 ```$ git merge [nome-do-branch]```
 
-Combina o histórico do branch específico ao branch atual
+Combina o histórico do branch especificado ao branch atual
 
 
 ```$ git branch -d [nome-do-branch]```
 
-Exclui o branch específico
+Exclui o branch especificado
 
 
 ## Refatore nomes dos arquivos

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -132,7 +132,7 @@ Remove o arquivo do controle de versão mas preserva o arquivo localmente
 Muda o nome do arquivo e o seleciona para o commit
 
 ## Suprima o rastreamento
-Exclua arquivos e diretórios temporários
+Ignore arquivos e diretórios temporários
 
 ```
 *.log

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -1,12 +1,12 @@
 ---
 layout: cheat-sheet
-title: GitHub Folha de dicas de Git
+title: Folha de Dicas de Git do GitHub
 byline: Git é um sistema de controle de versão distribuído open source que facilita ações com o GitHub em seu notebook ou desktop. Esta folha de dicas resume instruções comumente usadas via linha de comando do Git para referência rápida.
 leadingpath: ../../
 ---
 
 
-# GitHub Folha de dicas de Git
+# Folha de Dicas de Git do GitHub
 
 Git é um sistema de controle de versão distribuído open source que facilita ações com o GitHub em seu notebook ou desktop. Esta folha de dicas resume instruções comumente usadas via linha de comando do Git para referência rápida.
 

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -105,7 +105,7 @@ Muda para o branch específico e atualiza o diretório de trabalho
 
 ```$ git merge [nome-do-branch]```
 
-Combina o histórico do branch específico com o branch atual
+Combina o histórico do branch específico ao branch atual
 
 
 ```$ git branch -d [nome-do-branch]```
@@ -217,7 +217,7 @@ Baixe todo o histórico de um repositório remoto
 
 ```$ git merge [nome-remoto]/[branch]```
 
-Combina o branch remoto no branch local
+Combina o branch remoto ao branch local atual
 
 
 ```$ git push [alias] [branch]```

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -207,17 +207,17 @@ Desfaz todos os commits depois de `[commit]`, preservando mudanças locais
 Descarta todo histórico e mudanças para o commit especificado
 
 ## Sincronize mudanças
-Registre um marcador de repositório e troque o histórico de versão
+Registre um repositório remoto e troque o histórico de versão
 
 
-```$ git fetch [marcador]```
+```$ git fetch [nome-remoto]```
 
-Baixe todo o histórico de um marcador de repositório
+Baixe todo o histórico de um repositório remoto
 
 
-```$ git merge [marcador]/[branch]```
+```$ git merge [nome-remoto]/[branch]```
 
-Combina o marcador do branch no branch local
+Combina o branch remoto no branch local
 
 
 ```$ git push [alias] [branch]```

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -62,7 +62,7 @@ Lista todos os arquivos novos ou modificados para serem commitados
 
 ```$ git diff```
 
-Mostra diferenças no arquivo que não foram preparadas
+Mostra diferenças no arquivo que ainda não foram preparadas
 
 
 ```$ git add [arquivo]```

--- a/downloads/pt/github-git-cheat-sheet.md
+++ b/downloads/pt/github-git-cheat-sheet.md
@@ -10,7 +10,7 @@ leadingpath: ../../
 
 Git é um sistema de controle de versão distribuído open source que facilita ações com o GitHub em seu notebook ou desktop. Esta folha de dicas resume instruções comumente usadas via linha de comando do Git para referência rápida.
 
-## Instale o git
+## Instale o Git
 GitHub fornece clientes desktop que incluem uma interface gráfica para as ações mais comuns em um repositório e atualiza automaticamente para a linha de comando do Git para cenários avançados.
 
 ### GitHub para Windows
@@ -21,7 +21,7 @@ GitHub fornece clientes desktop que incluem uma interface gráfica para as açõ
 
 Distribuições do Git para Linux e sistemas POSIX são disponíveis no site oficial do Git SCM.
 
-### Git para todas plataformas
+### Git para todas as plataformas
 [http://git-scm.com](http://git-scm.com)
 
 ## Configure a ferramenta
@@ -30,12 +30,12 @@ Configure informações de usuário para todos os repositórios locais
 
 ```$ git config --global user.name "[nome]"```
 
-Configura o nome que você quer ligado as suas transações de commit
+Configura o nome que você quer ligado às suas transações de commit
 
 
 ```$ git config --global user.email "[endereco-de-email]"```
 
-Configura o email que você quer ligado as suas transações de commit
+Configura o email que você quer ligado às suas transações de commit
 
 
 ## Crie repositórios
@@ -72,7 +72,7 @@ Faz o snapshot de um arquivo na preparação para versionamento
 
 ```$ git diff --staged```
 
-Mostra a diferença entre arquivos preparados e a suas últimas versões
+Mostra a diferença entre arquivos preparados e suas últimas versões
 
 
 ```$ git reset [arquivo]```
@@ -113,7 +113,7 @@ Combina o histórico do branch especificado ao branch atual
 Exclui o branch especificado
 
 
-## Refatore nomes dos arquivos
+## Refatore nomes de arquivos
 Mude e remova os arquivos versionados
 
 
@@ -140,7 +140,7 @@ build/
 temp-*
 ```
 
-Um arquivo de texto chamado `.gitignore` suprime o versionamento acidental de arquivos e diretórios correspondentes aos padrões específicados
+Um arquivo de texto chamado `.gitignore` suprime o versionamento acidental de arquivos e diretórios correspondentes aos padrões especificados
 
 
 ```$ git ls-files --other --ignored --exclude-standard```
@@ -170,7 +170,7 @@ Lista todos os conjuntos de alterações em stash
 
 Descarta os conjuntos de alterações mais recentes em stash
 
-## Revise histórico
+## Revise o histórico
 Navegue e inspecione a evolução dos arquivos do projeto
 
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ leadingpath: ./
         <p><a href="downloads/es/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Spanish</a></p>
         <p><a href="downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> French</a></p>
         <p><a href="downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Japanese</a></p>
-        <p><a href="downloads/pt/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Portugues</a></p>
+        <p><a href="downloads/pt/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Brazilian Portuguese</a></p>
 		<p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon octicon-cloud-download"></span> Chinese</a></p>
       </div>
       <div class="col-md-4 pull-right">


### PR DESCRIPTION
I did a few interactive rebases to attempt to group the changes, so that if some of them are not accepted, the commits can be easily removed. How do you usually work? Should these all be squashed into one final commit?

## Notes

In this PR, I am trying to translate things back to English to explain the changes to everyone. Let me now if I should clarify more.

#### Title

The previous title did not sound right. The one I propose sounds like `GitHub's Git Cheat Sheet`.

#### Use `Remote Repository` instead of `Marker`

I do not know where those were taken from, but it is very confusing to use `Marker` for `Remote`.

#### Use `Prepare` and `Monitor`

These changes were taken from Pro Git's translation, which IMO sound much better:

- I found that `Select` was being used for `Stage`, but it sounds too vague and there is no direct translation for that. On [section 1.3](https://git-scm.com/book/pt-br/v1/Primeiros-passos-No%C3%A7%C3%B5es-B%C3%A1sicas-de-Git), I noticed they used `Prepare`, which makes it a lot clearer.

- `Track` was translated correctly, but after reading [section 2.2](https://git-scm.com/book/pt-br/v1/Git-Essencial-Gravando-Altera%C3%A7%C3%B5es-no-Reposit%C3%B3rio) it seems that using `Monitor` describes better what actually happens.

I should point out that there is an inconsistency on the book, and there are sections that the other terms are used as well, probably more than the ones I chose.

#### Redo commits

The `Redo commits` section was translated to `Undo commits`. It seemed wrong, but that title is the one that best describe the section. It consists only of `git reset` commands, where you just undo commits. Maybe this is actually something that should be changed in the English version. 

#### Mentioning pt-BR

I did not mention that the cheat sheet is in *Brazilian* Portuguese because it would not follow the same template of the others. What if it all of them had to mention what languages they were written?

Thanks!