### PR TITLE
switch formatting for two column git translation

### DIFF
--- a/_stylesheets/page.scss
+++ b/_stylesheets/page.scss
@@ -190,3 +190,7 @@ footer {
     }
   }
 }
+
+.no-left-padding {
+  padding-left: 0px !important;
+}

--- a/index.html
+++ b/index.html
@@ -11,25 +11,36 @@ leadingpath: ./
 
   <div class="row col-md-12">
     <div class="col-md-7">
-      <h3>Cheat Sheets</h3>
-      <p>
-        Looking for a quick reference sheet of Git commands or migration from SVN?<br>
-        We've got just the documents, available for download in these languages:</p>
-      <div class="col-md-3">
-        <h4>Git</h4>
-        <p><a href="downloads/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> English</a></p>
-        <p><a href="downloads/es/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Spanish</a></p>
-        <p><a href="downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> French</a></p>
-        <p><a href="downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Japanese</a></p>
-        <p><a href="downloads/pt/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Brazilian Portuguese</a></p>
-		<p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon octicon-cloud-download"></span> Chinese</a></p>
+      <div class="col-md-12">
+        <h3>Cheat Sheets</h3>
+        <p>
+          Looking for a quick reference sheet of Git commands or migration from SVN?<br>
+          We've got just the documents, available for download in these languages:
+        </p>
+        <div class="col-md-2 pull-left">
+          <h4>Git</h4>
+        </div>
+        <div class="col-md-5 pull-right">
+          <h4>SVN Migration</h4>
+        </div>
       </div>
-      <div class="col-md-4 pull-right">
-        <h4>SVN Migration</h4>
-        <p><a href="downloads/subversion-migration.html"><span class="octicon octicon-cloud-download"></span> English</a></p>
+      <div class="col-md-12">
+        <div class="col-md-3">
+          <p><a href="downloads/github-git-cheat-sheet.pdf"><span class="octicon  octicon-cloud-download"></span> English</a></p>
+          <p><a href="downloads/es/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Spanish</a></p>
+          <p><a href="downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> French</a></p>
+          <p><a href="downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Japanese</a></p>
+          <p><a href="downloads/pt/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Brazilian Portuguese</a></p>
+          <p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Chinese</a></p>
+        </div>
+        <div class="col-md-4">
+          <p><a href="downloads/it/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Italian</a></p>
+        </div>
+        <div class="col-md-4">
+          <p><a href="downloads/subversion-migration.html"><span class="octicon   octicon-cloud-download"></span> English</a></p>
+        </div>
       </div>
     </div>
-
     <div class="col-md-5">
       <h4>Community contributions</h4>
       <p>

--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@ leadingpath: ./
 
 <div class="container">
 
-  <h2>Open source training content</h2>
+  <h1>Open source training content</h1>
   <p>Present your way to better version control.</p>
 
   <div class="row col-md-12">
     <div class="col-md-7">
       <div class="col-md-12">
-        <h3>Cheat Sheets</h3>
+        <h2>Cheat Sheets</h2>
         <p>
           Looking for a quick reference sheet of Git commands or migration from SVN?<br>
           We've got just the documents, available for download in these languages:
@@ -30,10 +30,11 @@ leadingpath: ./
           <p><a href="downloads/es/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Spanish</a></p>
           <p><a href="downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> French</a></p>
           <p><a href="downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Japanese</a></p>
-          <p><a href="downloads/pt/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Brazilian Portuguese</a></p>
-          <p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Chinese</a></p>
+
         </div>
         <div class="col-md-4">
+          <p><a href="downloads/pt/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Brazilian Portuguese</a></p>
+          <p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Chinese</a></p>
           <p><a href="downloads/it/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Italian</a></p>
         </div>
         <div class="col-md-4">
@@ -42,7 +43,7 @@ leadingpath: ./
       </div>
     </div>
     <div class="col-md-5">
-      <h4>Community contributions</h4>
+      <h3>Community contributions</h3>
       <p>
         Would you like to update or clarify content in the slides or workbooks?
         Just fork the repository, make your changes, and submit a Pull Request.
@@ -51,7 +52,7 @@ leadingpath: ./
         <a href="https://github.com/github/training-kit">Head over to the github/training-kit repository</a>
       </p>
 
-      <h4>Let's be social</h4>
+      <h3>Let's be social</h3>
       <p>
         Like us on <a href="https://facebook.com/GitHub">Facebook</a> and follow us on <a href="https://twitter.com/githubguides">Twitter</a> or <a href="https://plus.google.com/+GitHubGuides">Google+</a>. Stay up to date with the latest GitHub Training events.
       </p>

--- a/index.html
+++ b/index.html
@@ -9,22 +9,22 @@ leadingpath: ./
   <h1>Open source training content</h1>
   <p>Present your way to better version control.</p>
 
-  <div class="row col-md-12">
-    <div class="col-md-7">
+  <div class="row">
+    <div class="col-md-7 no-left-padding">
       <div class="col-md-12">
         <h2>Cheat Sheets</h2>
         <p>
           Looking for a quick reference sheet of Git commands or migration from SVN?<br>
           We've got just the documents, available for download in these languages:
         </p>
-        <div class="col-md-2 pull-left">
+        <div class="col-md-2 pull-left no-left-padding">
           <h4>Git</h4>
         </div>
         <div class="col-md-5 pull-right">
           <h4>SVN Migration</h4>
         </div>
       </div>
-      <div class="col-md-12">
+      <div class="col-md-12 no-left-padding">
         <div class="col-md-3">
           <p><a href="downloads/github-git-cheat-sheet.pdf"><span class="octicon  octicon-cloud-download"></span> English</a></p>
           <p><a href="downloads/es/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Spanish</a></p>


### PR DESCRIPTION
Hate such a big commit, but because of div tags being spread out on the new formatting, i took the approach of just one single commit.
![screen shot 2015-08-26 at 4 04 07 pm](https://cloud.githubusercontent.com/assets/45141/9509546/d5a3e634-4c15-11e5-99b4-0c0a47ab7372.png)


cc @github/training-teachers for some feedback. We'll also need to incorporate this into training-web afterwards.