### PR TITLE
Rework timer to work as expected when sleeping

### DIFF
--- a/_layouts/module.html
+++ b/_layouts/module.html
@@ -52,7 +52,7 @@ layout: site
 <!-- Modal -->
 <div class="modal fade" id="timerModal" tabindex="-1" role="dialog" aria-labelledby="timerModalLabel" aria-hidden="true">
   <div class="modal-dialog">
-    <div class="modal-content text-center">
+    <form id='timerForm' class="modal-content text-center">
       <input type="number" id="minutes" name="minutes" min="1" max="60" value="5" placeholder="min" class="form-control time-amount">
       <div class="time-left" id="time-left"></div>
 
@@ -60,7 +60,7 @@ layout: site
         <button id="start-stop" type="submit" class="btn btn-default">Start</button>
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
       </div>
-    </div>
+    </form>
   </div>
 </div>
 


### PR DESCRIPTION
I've run into this problem where the on-screen timer doesn't update the countdown in some circumstances. Usually this is just a mildly annoying/humorous glitch -- the countdown says that there's "39 minutes left" when we all know that's not quite right -- but it came up in both of my recent on-site classes and I wanted to investigate a bit.

The old timer works something like this:

```
duration = x
every second:
  duration = duration - 1
  display duration
```

The problem with this is if something interrupts the `every second` check, the duration doesn't shrink.

The new timer works more like this:

```
time to stop = x
every second:
  duration = how long until time to stop
  display duration
```

This way, even if (some/any) of the `every second` checks get interrupted (laptop is sleeping, etc.) the next one (less than 1 second away) will update the display with the new/correct time.

Because I'm a nerd, I restructured the JS code a bit, while I was in here. It's arguably unnecessary, but it felt good.

Bonus: the timer is now actually a `<form>`, so you should be able to activate the timer with the `<enter>` key!