### PR TITLE
Removed usage of "either" in list of file states.

### DIFF
--- a/_modules/CONT-CLI-04_Two_Stage_Commit.md
+++ b/_modules/CONT-CLI-04_Two_Stage_Commit.md
@@ -14,7 +14,7 @@ screens:
       title: The Two Stage Commit
       image: two-stage-commit-b.jpg
       presenter-script:
-        - When you work locally, your files exist in one of four states. They are either untracked, modified, staged, or committed.
+        - When you work locally, your files exist in one of four states: untracked, modified, staged, or committed.
         - An untracked file is one that is not currently part of the version controlled directory.
   - image-slide:
       title: The Two Stage Commit

--- a/_modules/CONT-GHM-04_Two_Stage_Commit.md
+++ b/_modules/CONT-GHM-04_Two_Stage_Commit.md
@@ -10,7 +10,7 @@ screens:
       image: two-stage-commit-a.jpg
       presenter-script:
         - After you have finished making your changes, it is time to commit them. When working in the desktop app, you will need to be familiar with the idea of the two stage commit.
-        - When you work locally, your files exist in one of four states. They are either untracked, modified, staged, or committed.
+        - When you work locally, your files exist in one of four states: untracked, modified, staged, or committed.
         - When you are ready to add these files to version control, you will create a collection of files that represent a discrete unit of work. We build this unit in the changes tab of the desktop app.
         - When we are satisfied with the unit of work we have assembled, we will commit it.
         - Let's do it now.


### PR DESCRIPTION
I removed the word "either" in the list of file states. I believe either should be used when only two options are available.