### PR TITLE
Remove local repo from first segment in Everyone

### DIFF
--- a/_courses/github-for-everyone.md
+++ b/_courses/github-for-everyone.md
@@ -13,7 +13,6 @@ sections:
       - COLL-01_Exploring-a-repository
       - COLL-02_Using-issues
       - COLL-03_Watching-notifications-stars-explore
-      - CONT-CLI-14_Creating-repository-local
   -
     title: Creating Your First Pull Request
     description: In this section you will learn about the GitHub flow and create your first pull request.


### PR DESCRIPTION
[This line](https://github.com/github/training-kit/blame/master/_courses/github-for-everyone.md#L16) has been here since the initial import, but I can't make it make sense in my head and none of the videos I've reviewed actually show anyone doing this at all, let alone as the ~fifth thing in class.

I'm not sure what this is supposed to be, but my guess is that it should just go. :hocho: 

@github/training-teachers thoughts? objections? theories? explanations? concerns?