### PR TITLE
add link to pt-pt cheatsheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,9 +33,8 @@ leadingpath: ./
 
         </div>
         <div class="col-md-4">
-          <p><a href="downloads/pt_BR/github-git-cheat-sheet.html"><span class="octicon   octicon-cloud-download"></span> Brazilian Portuguese</a></p>
-          <!-- pt_PT is not yet ready for rendering
-          <p><a href="downloads/pt/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Portuguese</a></p> -->
+          <p><a href="downloads/pt_BR/github-git-cheat-sheet.html"><span class="octicon   octicon-cloud-download"></span> Portuguese - Brazil</a></p>
+          <p><a href="downloads/pt_PT/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Portuguese - Portugal</a></p>
           <p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Chinese</a></p>
           <p><a href="downloads/it/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Italian</a></p>
         </div>


### PR DESCRIPTION
This PR relabels the way Portuguese cheat sheets are presented so there's a separation between pt_BR and pt_PT. It also introduces the pt_PT to the kit landing page. Merging this myself since this is a pretty small change that should've really been introduced in #359 