### PR TITLE
Remove slide captures from advanced

### DIFF
--- a/advanced/index.md
+++ b/advanced/index.md
@@ -49,60 +49,69 @@ Explore the structure and way change is preserved in Git.
 
 ---
 
+---
 
-{% capture slide %}
 ```
 git log [branch]..[branch]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 git log [branch]...[branch]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git log --left-right
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git log --diff-filter=[A|M|D]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git branch --merged
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 git branch --no-merged
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 git rev-parse [commit-shorthand]
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 git name-rev [commit]
 ```
-{% endcapture %}{% include slide-section %}
+
+---
 
 {% capture lab %}
 1. Understand the way Git preserves history and data
@@ -176,43 +185,53 @@ Cutting and creating releases on the command line and on GitHub.
 
 ---
 
+---
 
-{% capture slide %}
 ```
 git tag [tagname] [commit]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 git tag -a [tagname] [commit]
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 git push [remote] [tagname]
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 git tag -d [tagname]
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 git describe
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 git tag -s -m "[message]" [tagname] [commit]
 ```
-{% endcapture %}{% include slide-section %}
+
+---
 
 {% capture lab %}
 1. Use the command line for branching strategies
@@ -220,8 +239,11 @@ git tag -s -m "[message]" [tagname] [commit]
 3. Apply `tag`s to commits to indicate releases
 {% endcapture %}{% include lab %}
 
+---
 
 ![Tags](../assets/diagrams/tag.svg)
+
+---
 
 ### Details
 
@@ -294,38 +316,39 @@ Avoid tracking unimportant files.
 
 ---
 
+---
 
-{% capture slide %}
 ```
 $ vi .gitignore
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
+---
 
-{% capture slide %}
 ```
 $ git config core.excludesfile [path]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git add -f [path]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git clean -f
 $ git clean -fd
 $ git clean -fx
 ```
-{% endcapture %}{% include slide-section %}
 
-
+---
 
 {% capture lab %}
 1. Set ignore patterns to prevent accidental versioning
@@ -382,35 +405,40 @@ Speed up your workflow.
 
 ---
 
+---
 
-
-{% capture slide %}
 ```
 $ git commit -a -m"[message]"
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 $ git commit --amend -m "[updated message]"
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 $ git checkout -b [branch] [base]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git stash
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 # Stage by patch
 $ git add -p [file]
@@ -418,9 +446,8 @@ $ git add -p [file]
 # Unstage by patch
 git reset HEAD -p [file]
 ```
-{% endcapture %}{% include slide-section %}
 
-
+---
 
 {% capture lab %}
 1. Use built-in shortcuts for committing and branch switching
@@ -483,14 +510,12 @@ git reset HEAD -p [file]
 ```
 
 #### Avoiding repetitive conflicts
-* *Re*use *re*corded *re*solution
-* Preserves pre-image to simplify conflicts
+- **Re**use **re**corded **re**solution
+- Preserves pre-image to simplify conflicts
 
 ```shell
 $ git config rerere.enable true
 ```
-
-
 
 ---
 
@@ -500,10 +525,8 @@ Craft and acquire commits with selective, as-needed commands.
 
 ---
 
+---
 
-
-
-{% capture slide %}
 ```
 # Generate new commit from specified commit
 $ git cherry-pick [commit]
@@ -511,17 +534,17 @@ $ git cherry-pick [commit]
 # List branches containing same patch
 $ git cherry [comparison-branch]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 # Stage the file from a specific commit
 git checkout [commit] -- [path]
 ```
-{% endcapture %}{% include slide-section %}
 
-
+---
 
 
 {% capture lab %}
@@ -579,29 +602,28 @@ Rebase and reorder existing commits for improved historical context.
 
 ---
 
-{% capture slide %}
 ```
 $ git rebase [base-commit]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
+---
 
-{% capture slide %}
 ```
 $ git pull --rebase
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
+---
 
-{% capture slide %}
 ```
 $ git config branch.autosetuprebase
 $ git config branch.[master].rebase true
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
 ---
 
@@ -615,19 +637,22 @@ $ git config branch.[master].rebase true
 
 ---
 
+---
 
-{% capture slide %}
 ```
 $ git rebase -i [base-commit]
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 # When commits contain `fixup!` or `squash!`
 $ git rebase -i --autosquash [base-commit]
 ```
-{% endcapture %}{% include slide-section %}
+
+---
 
 {% capture lab %}
 1. Replay branch history with `rebase`
@@ -695,61 +720,64 @@ Interact, investigate, and integrate remote repository histories.
 
 ---
 
+---
 
-{% capture slide %}
 ```shell
 $ git remote -v
 $ git branch -vv
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git remote show <remote-name>
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```shell
 # List refs of upstream
 $ git ls-remote [remote]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 git pull [remote] [pull-request-namespace]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
+---
 
-{% capture slide %}
 ```
 # Retrieve, store as temporary branch
 $ git fetch [remote] refs/pull/[num]/head
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 $ git show FETCH_HEAD
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 $ git merge --no-commit --no-ff FETCH_HEAD
 ```
-{% endcapture %}{% include slide-section %}
 
-
-
-
-
+---
 
 
 {% capture lab %}
@@ -839,8 +867,8 @@ Separate single, large repository histories into individual projects.
 
 ---
 
+---
 
-{% capture slide %}
 ```shell
 # Rewrite all history with
 # respect to files in directory
@@ -848,9 +876,11 @@ $ git filter-branch
 --subdirectory-filter [dir]
 -- --all
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```
 # Rewrite history, applying Git command
 # across all commits
@@ -858,17 +888,19 @@ $ git filter-branch --index-filter
 'git rm --cached
 --ignore-unmatch [file]' HEAD
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git submodule add [repo-url] [folder]
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 $ git submodule init
 $ git submodule update
@@ -877,7 +909,8 @@ $ git submodule update
 
 $ git clone --recursive [url]
 ```
-{% endcapture %}{% include slide-section %}
+
+---
 
 
 {% capture lab %}
@@ -929,26 +962,31 @@ Verify authenticity with GPG keys
 
 ---
 
-{% capture slide %}
+---
+
 ```shell
 $ git commit --signoff
 ```
-{% endcapture %}{% include slide-section %}
 
-{% capture slide %}
+---
+
+---
+
 ```shell
 # Display signatures per commit
 $ git log --show-signature
 ```
-{% endcapture %}{% include slide-section %}
 
+---
 
-{% capture slide %}
+---
+
 ```
 # Merge only if all signatures match public keys
 $ git merge --verify-signatures
 ```
-{% endcapture %}{% include slide-section %}
+
+---
 
 
 {% capture lab %}


### PR DESCRIPTION
This PR resolves #372. The need for the slide capture syntax was removed in https://github.com/github/training-kit/commit/933ce3a7b8a3b7aace864088d50bd184a982e290 but it snuck back in to this doc when I resolved a merge conflict. This PR changes it back to markdown only!