### PR TITLE
Fix broken link to GitHub Importer in SVN Migration cheat sheet

### DIFF
--- a/downloads/subversion-migration.md
+++ b/downloads/subversion-migration.md
@@ -15,9 +15,7 @@ The process is as simple, needing only you to sign into your GitHub account, if 
 
 Depending on the detected version control system, Importer may request additional information for migration. This includes a mapping file for associating Subversion usernames with Git fields.
 
-Begin migrating repositories by visiting the Importer home page:
-
-[https://importer.github.com](https://importer.github.com)
+Read more about how to import your project into GitHub by looking at the full [GitHub Importer documentation](https://help.github.com/articles/importing-a-repository-with-github-importer/).
 
 ### SVN2Git Utility
 


### PR DESCRIPTION
This PR includes a fix for the broken link to the GitHub Importer as identified in issue #385.

Because the proposed URL fix (import.github.com) only redirects successfully for logged in users, this PR is **WIP**, pending further discussion.

Once the ideal link is determined, I can go ahead and update this PR.