### PR TITLE
Update nav on the HTML cheat sheets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ title: GitHub Training
 # standard jekyll configuration
 
 baseurl: /kit
+parentsite: https://services.github.com
 permalink: /articles/:title
 exclude:
 - bin

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,9 +5,9 @@
         <ul class="text-left">
           <li>&copy; {{ site.time | date: '%Y' }} <span>GitHub</span>, Inc.</li>
           <li><a href="https://github.com/site/terms">Terms</a></li>
-          <li><a href="https://training.github.com/kit/license.html">License</a></li>
+          <li><a href="{{ site.baseurl }}/license.html">License</a></li>
           <li><a href="https://github.com/security">Security</a></li>
-          <li><a href="https://training.github.com/contact">Contact</a></li>
+          <li><a href="{{ site.parentsite }}/contact">Contact</a></li>
         </ul>
       </div>
 

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -15,11 +15,9 @@
       <div class="col-md-9 col-sm-10">
         <div class="collapse navbar-collapse navbar-right" id="main-navbar-collapse">
           <ul class="nav navbar-nav navbar-right">
-            <li><a{% if page.body_class == 'trainers' %} class="active"{% endif %} href="{{ site.url }}/trainers/">Trainers</a></li>
-            <li><a{% if page.body_class == 'classes' %} class="active"{% endif %} href="{{ site.url }}/classes/">Classes</a></li>
-            <li><a{% if page.body_class == 'schedule' %} class="active"{% endif %} href="{{ site.url }}/schedule/">Schedule</a></li>
-            <li><a class="active" href="{{ site.url }}/kit/">Kit</a></li>
-            <li><a{% if page.body_class == 'contact' %} class="active"{% endif %} href="{{ site.url }}/contact/">Contact</a></li>
+            <li><a{% if page.body_class == 'training' %} class="active"{% endif %} href="{{ site.parentsite }}/training/">Training</a></li>
+            <li><a{% if page.body_class == 'resources' %} class="active"{% endif %} href="{{ site.parentsite }}/resources/">Resources</a></li>
+            <li><a{% if page.body_class == 'contact' %} class="active"{% endif %} href="{{ site.parentsite }}/contact/">Contact</a></li>
           </ul>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@ leadingpath: ./
           <p><a href="downloads/es_ES/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Spanish</a></p>
           <p><a href="downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> French</a></p>
           <p><a href="downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Japanese</a></p>
+          <p><a href="downloads/ar/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Arabic</a></p>
 
         </div>
         <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ leadingpath: ./
 
         </div>
         <div class="col-md-4">
-          <p><a href="downloads/pt_BR/github-git-cheat-sheet.html"><span class="octicon   octicon-cloud-download"></span> Portuguese - Brazil</a></p>
+          <p><a href="downloads/pt_BR/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Portuguese - Brazil</a></p>
           <p><a href="downloads/pt_PT/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Portuguese - Portugal</a></p>
           <p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Chinese</a></p>
           <p><a href="downloads/it/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Italian</a></p>


### PR DESCRIPTION
The navigation on some cheat sheets that are generated in HTML is outdated. The changes introduced here should update the navigation to more closely resemble the nav used by the training team. 