### PR TITLE
Add Korean and German cheatsheets

### DIFF
--- a/downloads/kr/github-git-cheat-sheet.md
+++ b/downloads/kr/github-git-cheat-sheet.md
@@ -2,7 +2,7 @@
 layout: cheat-sheet
 title: GitHub Git Cheat Sheet
 byline: Git은 여러분의 노트북이나 데스크톱에서 GitHub을 사용할 수 있도록 해주는 오픈 소스 분산 버전 관리 시스템입니다. 해당 Cheat Sheet에서는 사용자가 빠르게 참고할 수 있도록 주로 사용되는 Git의 명령행(command line)을 간단히 요약하였습니다.
-leadingpath: ../
+leadingpath: ../../
 ---
 
 {% capture colOne %}

--- a/index.html
+++ b/index.html
@@ -26,18 +26,17 @@ leadingpath: ./
       </div>
       <div class="col-md-12 no-left-padding">
         <div class="col-md-3">
-          <p><a href="downloads/github-git-cheat-sheet.pdf"><span class="octicon  octicon-cloud-download"></span> English</a></p>
-          <p><a href="downloads/es_ES/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Spanish</a></p>
-          <p><a href="downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> French</a></p>
-          <p><a href="downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Japanese</a></p>
           <p><a href="downloads/ar/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Arabic</a></p>
-
+          <p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Chinese</a></p>
+          <p><a href="downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> French</a></p>
+          <p><a href="downloads/github-git-cheat-sheet.pdf"><span class="octicon  octicon-cloud-download"></span> English</a></p>
         </div>
         <div class="col-md-4">
+          <p><a href="downloads/it/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Italian</a></p>
+          <p><a href="downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Japanese</a></p>
           <p><a href="downloads/pt_BR/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Portuguese - Brazil</a></p>
           <p><a href="downloads/pt_PT/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Portuguese - Portugal</a></p>
-          <p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Chinese</a></p>
-          <p><a href="downloads/it/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Italian</a></p>
+          <p><a href="downloads/es_ES/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Spanish</a></p>
         </div>
         <div class="col-md-4">
           <p><a href="downloads/subversion-migration.html"><span class="octicon   octicon-cloud-download"></span> English</a></p>

--- a/index.html
+++ b/index.html
@@ -30,10 +30,12 @@ leadingpath: ./
           <p><a href="downloads/cn/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Chinese</a></p>
           <p><a href="downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> French</a></p>
           <p><a href="downloads/github-git-cheat-sheet.pdf"><span class="octicon  octicon-cloud-download"></span> English</a></p>
+          <p><a href="downloads/de/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> German</a></p>
+          <p><a href="downloads/it/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Italian</a></p>
         </div>
         <div class="col-md-4">
-          <p><a href="downloads/it/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Italian</a></p>
           <p><a href="downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Japanese</a></p>
+          <p><a href="downloads/kr/github-git-cheat-sheet.html"><span class="octicon  octicon-cloud-download"></span> Korean</a></p>
           <p><a href="downloads/pt_BR/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Portuguese - Brazil</a></p>
           <p><a href="downloads/pt_PT/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Portuguese - Portugal</a></p>
           <p><a href="downloads/es_ES/github-git-cheat-sheet.pdf"><span class="octicon   octicon-cloud-download"></span> Spanish</a></p>


### PR DESCRIPTION
Thanks to @bitoiu for noticing that the KR and DE cheatsheets weren't linked. This PR adds links to them to the training-kit. 