### PR TITLE
Update the Title on the CLI course

### DIFF
--- a/_includes/timeline.html
+++ b/_includes/timeline.html
@@ -81,8 +81,8 @@
                             </div>
                             <div class="timeline-panel">
                                 <div class="timeline-heading">
-                                    <!--<a href="/on-demand/github-cli/"><h2>GitHub 103: Using GitHub on the Command Line</h2></a>-->
-                                    <h2>GitHub 103: Using GitHub on the Command Line</h2>
+                                    <!--<a href="/on-demand/github-cli/"><h2>GitHub 103: Using the Command Line</h2></a>-->
+                                    <h2>GitHub 103: Using the Command Line</h2>
                                 </div>
                                 <div class="timeline-body">
                                     <p class="text-muted">Coming soon!</p>


### PR DESCRIPTION
@github/services-training this PR updates the title on the upcoming command line course to make it clear we are learning command line Git, not Hub. Will :ship: with 1 :+1:

P.S. this closes https://github.com/github/services-web/issues/630