### PR TITLE
Change --other to --others in ls-files

### DIFF
--- a/downloads/ar/github-git-cheat-sheet.md
+++ b/downloads/ar/github-git-cheat-sheet.md
@@ -151,7 +151,7 @@ temp-*
 <p dir="rtl">استخدام ملف نصي بمسمى <code dir="ltr">.gitignore</code> يمنع تتبع الملفات والمجلدات الغير مرغوبة بتحديد أنماط تسمية هذه الملفات</p>
 
 
-<p align="right"><code align="right">$ git ls-files --other --ignored --exclude-standard</code></p>
+<p align="right"><code align="right">$ git ls-files --others --ignored --exclude-standard</code></p>
 
 <p dir="rtl">سرد قائمة بكل الملفات التي تم تجاهلها في المشروع الحالي</p>
 

--- a/downloads/cn/github-git-cheat-sheet.md
+++ b/downloads/cn/github-git-cheat-sheet.md
@@ -150,7 +150,7 @@ temp-*
 文本文件`.gitignore`可以防止一些特定的文件进入到版本控制中
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 列出所有项目中忽略的文件
 

--- a/downloads/de/github-git-cheat-sheet.md
+++ b/downloads/de/github-git-cheat-sheet.md
@@ -143,7 +143,7 @@ temp-*
 Eine Textdatei namens `.gitignore` verhindert das versehentliche Committen von Dateien und Pfaden mit den spezifizierten Patterns
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 Listet alle innerhalb dieses Projekts ignorierten Dateien auf
 

--- a/downloads/es_ES/github-git-cheat-sheet.md
+++ b/downloads/es_ES/github-git-cheat-sheet.md
@@ -155,7 +155,7 @@ temp-*
 Un archivo de texto llamado `.gitignore` suprime la creación accidental de versiones para archivos y rutas que concuerdan con los patrones especificados
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 Enumera todos los archivos ignorados en este proyecto
 

--- a/downloads/fr/github-git-cheat-sheet.md
+++ b/downloads/fr/github-git-cheat-sheet.md
@@ -157,7 +157,7 @@ temp-*
 Un fichier texte nommé `.gitignore` permet d'éviter le suivi de version accidentel pour les fichiers et chemins correspondant aux patterns spécifiés
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 Liste tous les fichiers exclus du suivi de version dans ce projet
 

--- a/downloads/github-git-cheat-sheet.md
+++ b/downloads/github-git-cheat-sheet.md
@@ -152,7 +152,7 @@ temp-*
 A text file named `.gitignore` suppresses accidental versioning of files and paths matching the specified patterns
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 Lists all ignored files in this project
 

--- a/downloads/it/github-git-cheat-sheet.md
+++ b/downloads/it/github-git-cheat-sheet.md
@@ -151,7 +151,7 @@ temp-*
 Un file di testo chiamato `.gitignore` previene il versioning accidentale di file o directory secondo un pattern specificato.
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 Elenca tutti i file ignorati in questo progetto
 

--- a/downloads/ja/github-git-cheat-sheet.md
+++ b/downloads/ja/github-git-cheat-sheet.md
@@ -152,7 +152,7 @@ temp-*
 `.gitignore` という名前のテキストファイルで、指定されたパターンに該当するファイルやパスを誤ってバージョン管理してしまうことを防げます
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 プロジェクト内のすべての除外されたファイルを一覧で表示します
 

--- a/downloads/kr/github-git-cheat-sheet.md
+++ b/downloads/kr/github-git-cheat-sheet.md
@@ -147,7 +147,7 @@ temp-*
 `.gitignore`이름의 텍스트 파일은 특정 패턴으로 매칭되는 우연히 버저닝된 파일과 경로를 숨깁니다
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 해당 프로젝트에서 무시된 모든 파일 리스트를 보여줍니다
 

--- a/downloads/pt_BR/github-git-cheat-sheet.md
+++ b/downloads/pt_BR/github-git-cheat-sheet.md
@@ -150,7 +150,7 @@ temp-*
 Um arquivo de texto chamado `.gitignore` suprime o versionamento acidental de arquivos e diretórios correspondentes aos padrões especificados
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 Lista todos os arquivos ignorados neste projeto
 

--- a/downloads/pt_PT/github-git-cheat-sheet.md
+++ b/downloads/pt_PT/github-git-cheat-sheet.md
@@ -150,7 +150,7 @@ temp-*
 Um ficheiro `.gitignore` na raiz do projecto previne o versionamento acidental de ficheiros e diretórios correspondentes aos padrões especificados
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 Lista todos os ficheiros e directórios ignorados neste projeto
 

--- a/downloads/sk/github-git-cheat-sheet.md
+++ b/downloads/sk/github-git-cheat-sheet.md
@@ -156,7 +156,7 @@ temp-*
 Textový súbor nazvaný `.gitignore` zakáže verzovanie nechcených súborov alebo priečinkov (väčšinou napr. súbory IDE, heslá).
 
 
-```$ git ls-files --other --ignored --exclude-standard```
+```$ git ls-files --others --ignored --exclude-standard```
 
 Vráti zoznam všetkých ignorovaných súborov v projekte
 


### PR DESCRIPTION
Per an email report, the cheat sheets currently show the use of `--other` instead of `--others` as an option for the ls-files command. The [online documentation shows that `--others` is the correct option](https://git-scm.com/docs/git-ls-files). This fixes the .md files, but leaves the PDFs untouched for now. This will also need to be fixed in #403.

Will :ship: with one approved review!

/cc @github/services-training FYI