### PR TITLE
Create learning path file

### DIFF
--- a/self-study.md
+++ b/self-study.md
@@ -1,8 +1,8 @@
 ---
 layout: single
-title: Self Study
+title: Training Path
 category: self-study
-permalink: /self-study/
+permalink: /path/
 header:
   overlay_color: "#137bce"
 ---

--- a/self-study.md
+++ b/self-study.md
@@ -1,0 +1,54 @@
+---
+layout: single
+title: Self Study
+category: self-study
+permalink: /self-study/
+header:
+  overlay_color: "#137bce"
+---
+
+Learning Git and GitHub can seem daunting but with this helpful list of training resources, you will be a Git-guru in no time.
+
+# A Path to Learning GitHub (and Git)
+
+## Just Getting Started
+
+| | Title | Time
+| --- | --- | ---
+| :computer: | [On Demand: Introduction to GitHub](https://services.github.com/on-demand/intro-to-github/) | 30:00
+| :computer: | [On Demand: Using GitHub Desktop](https://services.github.com/on-demand/github-desktop/) | 30:00
+| :tv: | [Setup Git](https://www.youtube.com/watch?v=7Inc0G0wutk) | 2:15
+| | **Total** | ~1:02:15
+
+
+## Ready for Next Steps
+
+| | Title | Time
+| --- | --- | ---
+| :tv: | [Creating New Repositories](https://youtu.be/WxMFZncm12s) | 2:25
+| :tv: | [Understanding Branches](https://youtu.be/H5GJfcp3p4Q) | 2:25
+| :tv: | [Changing Your View of the Repository](https://youtu.be/HwrPhOp6-aM) | 3:11
+| :tv: | [Merge Conflicts](https://youtu.be/yyLiplDQtf0) | 4:50
+| :tv: | [Using Diffs](https://youtu.be/RXSriVcoI70) | 3:33
+| :tv: | [Using Git Log](https://youtu.be/Ew8HQsFyVHo) | 4:57
+| | **Total** | ~ 21 minutes
+| :computer: | [A Visualization Tool for Learning Git](http://learngitbranching.js.org/) |
+
+## Setting Your Team Up for Success
+
+| | Title | Time
+| --- | --- | ---
+| :clipboard: | [GitHub Flow](https://guides.github.com/introduction/flow/) | 4:00
+| :tv: | [Setting up a .gitignore](https://youtu.be/4VBG9FlyiOw) | 3:06
+| | **Total** | ~ 7 minutes
+
+## Already Comfortable, Ready for the Hard(er) Stuff
+
+| | Title | Time
+| --- | --- | ---
+| :clipboard: | [How to Undo Almost Anything with Git](https://github.com/blog/2019-how-to-undo-almost-anything-with-git) | 7:30
+| :tv: | [More on Reset](https://youtu.be/BKPjPMVB81g) | 3:47
+| :tv: | [Using Reflog](https://youtu.be/Vxc9m_OVyo0) | 3:28
+| :tv: | [Using Rebase](https://youtu.be/SxzjZtJwOgo) | 4:20
+| :clipboard: | [Working with Submodules](https://github.com/blog/2104-working-with-submodules) | 4:30
+| | **Total** | ~23 minutes


### PR DESCRIPTION
I originally named this file 'self-study' but based on a recommendation by @crichID I think it should be set to 'learning-path', so I need to fix that. 

I am making this PR as an opportunity to provide a list of guides and learning opportunities for newcomers to Git and GitHub. Times are based on me reading the different articles at a decent pace, so they aren't 100% accurate, but probably not off by too much.

Let me know what you think. @github/services-training  

It is currently accessed locally by adding this to the server address: `on-demand/self-study/`