### PR TITLE
Update with 2017 holidays

### DIFF
--- a/us-holidays.md
+++ b/us-holidays.md
@@ -9,12 +9,13 @@ header:
 
 Date          | Holiday
 ---           | ---
-January 01    | New Years Day
+January 02    | New Years Day
 January 16    | Martin Luther King Day (Third Monday in January)
 February 20   | Presidents Day (3rd Monday in February)
 May 29        | Memorial Day (Last Monday in May)
 July 04       | Independence Day
 September 04  | Labor Day (First Monday in September)
-November 11   |	Veterans Day
+November 10   |	Veterans Day
 November 23-24|	Thanksgiving (Fourth Thursday in November)
+December 22   | Christmas Eve
 December 25   |	Christmas Day

--- a/us-holidays.md
+++ b/us-holidays.md
@@ -5,6 +5,7 @@ permalink: /community/us-holidays/
 header:
   overlay_color: "#137bce"
 ---
+## 2017
 
 Date          | Holiday
 ---           | ---

--- a/us-holidays.md
+++ b/us-holidays.md
@@ -10,12 +10,11 @@ header:
 Date          | Holiday
 ---           | ---
 January 01    | New Years Day
-January 18    | Martin Luther King Day (Third Monday in January)
-February 15   | Presidents Day (3rd Monday in February)
-May 30        | Memorial Day (Last Monday in May)
+January 16    | Martin Luther King Day (Third Monday in January)
+February 20   | Presidents Day (3rd Monday in February)
+May 29        | Memorial Day (Last Monday in May)
 July 04       | Independence Day
-September 05  | Labor Day (First Monday in September)
-November 8    | Voting Day
+September 04  | Labor Day (First Monday in September)
 November 11   |	Veterans Day
-November 24-25|	Thanksgiving (Fourth Thursday in November)
+November 23-24|	Thanksgiving (Fourth Thursday in November)
 December 25   |	Christmas Day


### PR DESCRIPTION
The on-demand site lists the dates when GitHub's trainers will not be available to offer assistance via Gitter. This PR updates the list to reflect the actual dates for 2017.

I also added a heading so people would know which year was reflected in the chart!

@github/services-training will merge with 1 :+1: