### PR TITLE
Remove beta tags from Desktop & CLI

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,10 +4,8 @@ main:
   - title: "Introduction to GitHub"
     url: /intro-to-github/
   - title: "Using GitHub Desktop"
-    beta: true
     url: /github-desktop/
   - title: "Using the Command Line"
-    beta: true
     url: /github-cli/
   - title: "Community"
     url: /community/

--- a/_includes/timeline.html
+++ b/_includes/timeline.html
@@ -64,7 +64,6 @@
                                     <a href="/on-demand/github-desktop/"><h2>GitHub 102: Using GitHub Desktop</h2></a>
                                 </div>
                                 <div class="timeline-body">
-                                  <span class="btn btn--inverse">BETA</span>
                                     <p class="text-muted">Learn how to <b>use GitHub Desktop</b> to copy a repository to your computer, track changes and communicate with GitHub.</p>
                                 </div>
                             </div>
@@ -84,7 +83,6 @@
                                     <a href="/on-demand/github-cli/"><h2>GitHub 103: Using the Command Line</h2></a>
                                 </div>
                                 <div class="timeline-body">
-                                      <span class="btn btn--inverse">BETA</span>
                                         <p class="text-muted">Learn how to <b>use the Command Line</b> to copy a repository to your computer, track changes and communicate with GitHub.</p>
                                 </div>
                             </div>


### PR DESCRIPTION
This pull request removes the beta tags from the Desktop and the CLI course in both the nav head and the timeline.

This shouldn't be merged until the tests are merged into the class repository [from this PR](https://github.com/githubschool/on-demand-github-pages/pull/60). 

@github/services-training Does this look OK to you? Is there anything else we're waiting on to remove the beta tags? 