### PR TITLE
Fix leading path in cheat sheets so html will render properly

### DIFF
--- a/downloads/es_ES/github-git-cheat-sheet.md
+++ b/downloads/es_ES/github-git-cheat-sheet.md
@@ -2,7 +2,7 @@
 layout: cheat-sheet
 title: Hoja de referencia para Git de Github
 byline: Git es el sistema de control de versiones distribuido de código abierto que facilita realizar actividades de Github en tu computadora portátil o de escritorio. Esta hoja de referencia resume las instrucciones de línea de comandos comúnmente usadas para una rápida referencia.
-leadingpath: ../../
+leadingpath: ../../../
 ---
 
 {% capture colOne %}

--- a/downloads/fr/github-git-cheat-sheet.md
+++ b/downloads/fr/github-git-cheat-sheet.md
@@ -2,7 +2,7 @@
 layout: cheat-sheet
 title: Aide-mémoire GitHub Git
 byline: Git est le sytème de gestion de version décentralisé open source qui facilite les activités GitHub sur votre ordinateur. Cet aide-mémoire permet un accès rapide aux instructions des commandes Git les plus utilisées.
-leadingpath: ../../
+leadingpath: ../../../
 ---
 
 {% capture colOne %}

--- a/downloads/github-git-cheat-sheet.md
+++ b/downloads/github-git-cheat-sheet.md
@@ -2,7 +2,7 @@
 layout: cheat-sheet
 title: GitHub Git Cheat Sheet
 byline: Git is the open source distributed version control system that facilitates GitHub activities on your laptop or desktop. This cheat sheet summarizes commonly used Git command line instructions for quick reference.
-leadingpath: ../
+leadingpath: ../../
 ---
 
 {% capture colOne %}

--- a/downloads/ja/github-git-cheat-sheet.md
+++ b/downloads/ja/github-git-cheat-sheet.md
@@ -2,7 +2,7 @@
 layout: cheat-sheet
 title: GitHub Git チートシート
 byline: Gitはオープンソースとして配布されているバージョン管理システムです。Gitを使うと、あなたのノートまたはデスクトップパソコンから、GitHub上のアクティビティーを操作できます。この早見表にはコマンドラインからよく使われているGitの命令をまとめています。
-leadingpath: ../../
+leadingpath: ../../../
 ---
 {% capture colOne %}
 ## gitのインストール

--- a/downloads/pt_BR/github-git-cheat-sheet.md
+++ b/downloads/pt_BR/github-git-cheat-sheet.md
@@ -2,7 +2,7 @@
 layout: cheat-sheet
 title: Folha de Dicas de Git do GitHub (pt-BR)
 byline: Git é um sistema de controle de versão distribuído open source que facilita ações com o GitHub em seu notebook ou desktop. Esta folha de dicas resume instruções comumente usadas via linha de comando do Git para referência rápida.
-leadingpath: ../../
+leadingpath: ../../../
 ---
 
 {% capture colOne %}

--- a/downloads/pt_PT/github-git-cheat-sheet.md
+++ b/downloads/pt_PT/github-git-cheat-sheet.md
@@ -2,7 +2,7 @@
 layout: cheat-sheet
 title: Folheto de ajuda para Git do GitHub (pt-PT)
 byline: Git é um sistema distribuído open source de controlo de versões que permite interagir com o GitHub no seu portátil ou desktop. Este folheto de ajuda resume as instruções frequentemente usadas na linha de comando do Git para referência rápida.
-leadingpath: ../../
+leadingpath: ../../../
 ---
 
 {% capture colOne %}


### PR DESCRIPTION
This PR fixes a bug found in #427 with the rendering of the html cheat sheets. 

Will :ship: with 1 :+1:.