### PR TITLE
Change instructions so users will be added by creating an issue

### DIFF
--- a/_includes/activity/github-desktop/12-add-class-repo.md
+++ b/_includes/activity/github-desktop/12-add-class-repo.md
@@ -2,4 +2,4 @@ It's time to share your page with the world! To do that, you will follow the sam
 
 1. Visit the [class repository](https://github.com/githubschool/on-demand-github-pages/).
 1. Click the **Issues** tab.
-1. Request push access by leaving a comment on [Issue #1](https://github.com/githubschool/on-demand-github-pages/issues/1).
+1. Request push access by creating an [Issue](https://github.com/githubschool/on-demand-github-pages/issues/).

--- a/_includes/activity/intro-to-github/01-join-intro-repo.md
+++ b/_includes/activity/intro-to-github/01-join-intro-repo.md
@@ -1,4 +1,4 @@
 It's time to get your hands dirty! Use these steps to access our shared project:
 
 1. Sign in with your GitHub account.
-2. Navigate to our shared project and become a collaborator. Click on [this link](https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/927) and leave a comment. The GitHubTeacher user will auto-magically add you to our project as a collaborator.
+2. Navigate to our shared project and become a collaborator. Click on [this link](https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/) and create an issue. The GitHubTeacher user will auto-magically add you to our project as a collaborator.


### PR DESCRIPTION
## Overview
**TL;DR**

This changes the instructions so users will be added by creating an issue rather than commenting on an existing issue. 

This will need to be merged at the same time as [this related pull request in another repository having to do with managing the webhook](https://github.com/githubteacher/practice-sinatra/pull/4).

This solves several problems: 
- Users have been creating issues instead of commenting by mistake
- Threads can only have 2500 comments, which we have maxed out

### Next Steps
- [ ] Test and get 👍 

### Review

@github/services-training How does this look? Is this a direction we want to go? 
