### PR TITLE
Replace usage of push force by force-with-lease

### DIFF
--- a/_includes/tell-me-why/trouble-pushforcewithlease.md
+++ b/_includes/tell-me-why/trouble-pushforcewithlease.md
@@ -1,0 +1,5 @@
+## Push --force-with-lease
+
+The `push --force` command allows you to override a branch history. This can be problematic if another collaborator pushed some commits to the branch you are working on. If you forgot to fetch the latest updates before pushing with the `--force` flag, those commits will be deleted.
+
+On the other hand, the less known `--force-with-lease` flag checks if you have fetch the latest updates before you decided to rewrite history, avoiding problematic situations. If there are updates to the branch you are working on, and you didn't fetch them, the `--force-with-lease` will make the push command to fail.

--- a/_includes/tell-me-why/trouble-pushforcewithlease.md
+++ b/_includes/tell-me-why/trouble-pushforcewithlease.md
@@ -2,4 +2,4 @@
 
 The `push --force` command allows you to override a branch history. This can be problematic if another collaborator pushed some commits to the branch you are working on. If you forgot to fetch the latest updates before pushing with the `--force` flag, those commits will be deleted.
 
-On the other hand, the less known `--force-with-lease` flag checks if you have fetch the latest updates before you decided to rewrite history, avoiding problematic situations. If there are updates to the branch you are working on, and you didn't fetch them, the `--force-with-lease` will make the push command to fail.
+On the other hand, the less known `--force-with-lease` flag checks if you have fetched the latest updates before you decide to rewrite history, avoiding problematic situations. If there are updates to the branch you are working on, and you didn't fetch them, the `--force-with-lease` will make the push command fail.

--- a/paths/git-trouble/fc-commitsucks.md
+++ b/paths/git-trouble/fc-commitsucks.md
@@ -14,7 +14,7 @@ main-content: |
 
   Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/01) page.
 pushed: |
-  Before you begin worrying about that terrible commit message you have pushed to the remote, let's talk about the risks associated with fixing it. Fixing a commit message you have already pushed is going to require you to use `git push --force`. Using `push --force` can cause some **serious** problems for other collaborators on your project. The embarrassment of a mispelled :grin: word is nothing compared to the embarrassment of messing up your collaborators. If your commit is really that bad, or if causing problems doesn't trouble you, keep reading.
+  Before you begin worrying about that terrible commit message you have pushed to the remote, let's talk about the risks associated with fixing it. Fixing a commit message you have already pushed is going to require you to use `git push --force-with-lease`. Using `push --force-with-lease` can cause some **serious** problems for other collaborators on your project. The embarrassment of a mispelled :grin: word is nothing compared to the embarrassment of messing up your collaborators. If your commit is really that bad, or if causing problems doesn't trouble you, keep reading.
 
   Start by asking yourself:
 
@@ -28,7 +28,7 @@ pushed: |
    1. Use `git log --oneline` to ensure the commit you want to fix is at the top of the list.
    1. Enter: `git commit --amend`.
    1. Enter the desired commit message and close the text editor.
-   1. Enter: `git push --force` to force your change to your remote.
+   1. Enter: `git push --force-with-lease` to force your change to your remote.
 
   **BOOM** you just fixed your terrible commit message and you potentially caused problems for other collaborators. Congratulations!!! In all seriousness, editing a commit message might seem important at the time, but pushing a terrible commit message isn't the worst thing in the world, so it is recommended that you do this sparingly.
 
@@ -45,7 +45,7 @@ pushed: |
    1. The rebase will stop at the first commit to be edited. To begin editing the first commit message, enter `git commit --amend`. Your text editor will open, allowing you to edit the commit message.
    1. Close the text editor and enter: `git rebase --continue`.
    1. Repeat the two previous steps for each commit you would like to edit.
-   1. When you have edited the last commit, the rebase will finish. Enter: `git push --force` to push your new commits to the remote.
+   1. When you have edited the last commit, the rebase will finish. Enter: `git push --force-with-lease` to push your new commits to the remote.
 
 didnt-push: |
   You have a couple of options when it comes to fixing a bad commit message. First, you need to ask yourself:
@@ -76,6 +76,7 @@ show-me-how:
 tell-me-why:
   includes:
     - tell-me-why/trouble-commitamend.md
+    - tell-me-why/trouble-pushforcewithlease.md
     - tell-me-why/trouble-reset-xref.md
     - tell-me-why/trouble-rebase.md
 ---


### PR DESCRIPTION
## Overview
**TL;DR**
Recommend the usage of `git push --force-with-lease` instead of  `git push --force` 

closes #452 

### Review
should be ready for review @crichID 
