### PR TITLE
Change wrong ticks on line 44 to grave accent

### DIFF
--- a/paths/git-trouble/fc-commitbroke.md
+++ b/paths/git-trouble/fc-commitbroke.md
@@ -95,7 +95,7 @@ tell-me-why: |
 
   There are a few things that you should know about `reflog`, such as:
 
-  1. `reflog` is **local** only, so, you other collaborators are not going to be able to find files you deleted in their `reflog`s.
+  1. `reflog` is **local** only, so, your other collaborators are not going to be able to find files you deleted in their `reflog`s.
   1. `reflog` only displays commits for a limited time:
      - 30 days: 'Unreachable' objects, aka commits or modifications that were made to a branch that no longer exists.
      - 90 days: 'Reachable' objects, aka commits or modifications that were made to a branch that still exists.

--- a/paths/git-trouble/fc-wrongbranch.md
+++ b/paths/git-trouble/fc-wrongbranch.md
@@ -41,7 +41,7 @@ didnt-push: |
     1. Ensure you are on the branch you accidentally made those commits to. If you followed the 'Setting Up Your Scenario Environment' directions, you should have made a few commits to a branch named `test`.
     1. Enter: `git log --oneline` and identify the SHA-1 hash associated with the commit just before the first incorrect commit. In this case, let's pretend file 5 was the first one that should have been on the other branch.
     1. Enter: `git reset --mixed SHA-1`, where `SHA-1` is the SHA-1 associated with the **adding file 4** commit.
-    1. Enter: 'git status'. You should see files 5 and 6 in your working directory.
+    1. Enter: `git status`. You should see files 5 and 6 in your working directory.
     1. Enter: `git checkout -b correct`. This will create a new branch named `correct` and check you out to that branch.
     1. Enter: `git status`. Files 5 and 6 should still be in your working directory.
     1. Add both File 5 and File 6 by entering: `git add file* `.


### PR DESCRIPTION
Wrong ticks on line 44 "Enter: 'git status'." which results in showing `git status` not in code formatting. Should be grave accent ( `` )