### PR TITLE
capitalize word with in title

### DIFF
--- a/paths/github-cli/16-collaborate.md
+++ b/paths/github-cli/16-collaborate.md
@@ -3,7 +3,7 @@ layout: simple-class
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)
-title: Collaborate with GitHub Pull Requests
+title: Collaborate With GitHub Pull Requests
 permalink: /github-cli/collaborate-github-pull-requests
 next-page: /github-cli/merge-pull-request-github-showcase
 facilitator: false


### PR DESCRIPTION
This small PR capitalizes a word in title to see if it will fix a 404 happening in services-web