### PR TITLE
Replace 01 with git-set-up in URLs

### DIFF
--- a/_includes/tell-me-why/trouble-reset-xref.md
+++ b/_includes/tell-me-why/trouble-reset-xref.md
@@ -1,2 +1,2 @@
 ## Reset
-For more information on `git reset`, check out the 'Tell me why' section in the [Too Many (small) Commits](/on-demand/git-trouble/03) scenario.
+For more information on `git reset`, check out the 'Tell me why' section in the [Too Many (small) Commits](/on-demand/git-trouble/too-many-commits) scenario.

--- a/paths/git-trouble/fc-accidentcommit.md
+++ b/paths/git-trouble/fc-accidentcommit.md
@@ -12,7 +12,7 @@ sidebar:
 main-content: |  
   In the fervor of making some sweet changes to your repository you might accidentally commit changes before you were actually ready to. First, breathe, you can fix this; for real. Second, remember you aren't the first person who completely broke everything with a commit, heck, even the GitHub Trainers do it from time to time. So, now that you have found yourself in some :ahem: _very_ distinguished company, you can fix that gross commit.
 
-  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/01) page.
+  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/git-set-up) page.
 
 pushed: |
     Since we accidentally pushed our changes to the remote, you need to `revert` the commit (or commits) to prevent them creating any problems for other collaborators.

--- a/paths/git-trouble/fc-accidentcommit.md
+++ b/paths/git-trouble/fc-accidentcommit.md
@@ -51,9 +51,9 @@ tell-me-why: |
   The easiest way to think about `revert` is just making your repository do the exact opposite of an existing commit and creating a new commit to record that change. Revert is useful when trying to 'undo' the changes made in a specific commit, and even _more_ useful if you pushed a change that your want to reverse to your remote since it will always create a new commit and leave the original commit untouched.
 
   ## Reset
-  For more information on `git reset`, check out the 'Tell me why' section in the [Too Many (small) Commits](/on-demand/git-trouble/03) scenario.
+  For more information on `git reset`, check out the 'Tell me why' section in the [Too Many (small) Commits](/on-demand/git-trouble/too-many-commits) scenario.
 
   ## Commit --amend
-  For more information on `git commit --amend`, check out the 'Tell me why' section in the [Commit Message Sucks](/on-demand/git-trouble/04) scenario.
+  For more information on `git commit --amend`, check out the 'Tell me why' section in the [Commit Message Sucks](/on-demand/git-trouble/git-commit-message) scenario.
 
 ---

--- a/paths/git-trouble/fc-commitbroke.md
+++ b/paths/git-trouble/fc-commitbroke.md
@@ -101,8 +101,8 @@ tell-me-why: |
      - 90 days: 'Reachable' objects, aka commits or modifications that were made to a branch that still exists.
 
   ## Reset
-  For more information about `reset`, check out the 'Tell me why' section in the [Too Many (small) Commits](/on-demand/git-trouble/03) scenario.
+  For more information about `reset`, check out the 'Tell me why' section in the [Too Many (small) Commits](/on-demand/git-trouble/too-many-commits) scenario.
 
   ## Cherry-pick
-  For more information about `cherry-pick`, check out the 'Tell me why' section in the [Committed to the Wrong Branch!](/on-demand/git-trouble/05) scenario.  
+  For more information about `cherry-pick`, check out the 'Tell me why' section in the [Committed to the Wrong Branch!](/on-demand/git-trouble/git-commit-wrong-branch) scenario.  
 ---

--- a/paths/git-trouble/fc-commitbroke.md
+++ b/paths/git-trouble/fc-commitbroke.md
@@ -13,7 +13,7 @@ main-content: |
 
   Your well intentioned branch was supposed to introduce that awesome new feature, but after making a few commits, things aren't going as planned!   
 
-  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/01) page.
+  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/git-set-up) page.
 pushed: |
     This is what makes Git awesome! You can try new things and, when they don't work out, just get rid of them. First, ask yourself:
 

--- a/paths/git-trouble/fc-commitsucks.md
+++ b/paths/git-trouble/fc-commitsucks.md
@@ -12,7 +12,7 @@ sidebar:
 main-content: |  
   As you begin creating commits you might 'accidentally' create a commit message that is borderline atrocious; something like 'Fixed the thing'. Although you are definitely aware of the **thing** you just **fixed**, other collaborators (including future you) will not know what you fixed and more importantly, **why** you needed to fix it. Thankfully, Git is well aware of our tendency to craft terrible commit messages and has a handful of commands that save even the vaguest commit message.
 
-  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/01) page.
+  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/git-set-up) page.
 pushed: |
   Before you begin worrying about that terrible commit message you have pushed to the remote, let's talk about the risks associated with fixing it. Fixing a commit message you have already pushed is going to require you to use `git push --force-with-lease`. Using `push --force-with-lease` can cause some **serious** problems for other collaborators on your project. The embarrassment of a mispelled :grin: word is nothing compared to the embarrassment of messing up your collaborators. If your commit is really that bad, or if causing problems doesn't trouble you, keep reading.
 

--- a/paths/git-trouble/fc-manycommits.md
+++ b/paths/git-trouble/fc-manycommits.md
@@ -12,7 +12,7 @@ sidebar:
 main-content: |
   While working on your project, you might have made commits for every little change and created a commit history that looks more like an avalanche of information as opposed to a succinct list of the changes.
 
-  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/01) page.
+  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/git-set-up) page.
 pushed: |
     I know that avalanche of commits looks bad, but it doesn't need to be permanent. A lot of people unintentionally create problems by trying to use Git to fix something that has already been pushed to the remote.
 

--- a/paths/git-trouble/fc-wrongbranch.md
+++ b/paths/git-trouble/fc-wrongbranch.md
@@ -15,7 +15,7 @@ main-content: |
 
   Fear not! You can salvage those changes and put them where they belong!
 
-  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/01) page.
+  Keep in mind, all exercises expect you to have run the script to create files using the scripts found on the [Set Up Your Environment](/on-demand/git-trouble/git-set-up) page.
 pushed: |
     ## First Things First: Fix Master
 

--- a/paths/git-trouble/fc-wrongbranch.md
+++ b/paths/git-trouble/fc-wrongbranch.md
@@ -81,10 +81,10 @@ tell-me-why: |
   So, after you cherry-picked your commit you might have noticed that the SHA-1 associated with the commit is now different. That is because the SHA-1 doesn't just identify the file (or files) that have been committed. It actually contains a lot of additional information like Date, Time, Author, and other information. So, even though you might have created a commit with the exact same file from before, you will have a completely new SHA-1 hash for the commit. Pretty cool, huh?
 
   ## Revert
-  For more information about `revert`, check out the ‘Tell me why’ section in the [Accidental Commit](/on-demand/git-trouble/06) scenario.
+  For more information about `revert`, check out the ‘Tell me why’ section in the [Accidental Commit](/on-demand/git-trouble/accidental-git-commit) scenario.
 
   ## Reset
-  For more information about `reset`, check out the 'Tell me why' section in the [Too Many (small) Commits](/on-demand/git-trouble/03) scenario.
+  For more information about `reset`, check out the 'Tell me why' section in the [Too Many (small) Commits](/on-demand/git-trouble/too-many-commits) scenario.
 
   ### What Happened to File 4?
   When you were running the `git reset --mixed SHA-1` you might have expected `file4.md` to be included in the files that got sent to the Working Directory. This is a very misconception when it comes to `git reset`, so don't worry, you are not alone! When you run `git reset`, you are identifying the commit that you want to `reset` to.


### PR DESCRIPTION
## Overview
**TL;DR**
This PR fixes some broken links after changing the navigation structure. 

This PR closes #499 

### Review
I will 🚢 with 1 👍. CC/ @github/services-training for testing. To test, go to `git-out-of-trouble` and click links in paragraphs that will redirect you to 'getting set up'. 

cc/ @mwiesen 