### PR TITLE
Remove chat option from on-demand

### DIFF
--- a/_includes/activity/gh-pages/02-create-profile.md
+++ b/_includes/activity/gh-pages/02-create-profile.md
@@ -30,5 +30,5 @@ Don't worry if you don't want to put your actual information up online. It's OK 
   {{ activity-text | markdownify }}
 </div>
 
-Need help? Click **open chat** below for answers from GitHub trainers!
+Need help? **Open an issue** [in our class repository](https://github.com/githubschool/on-demand-github-pages/issues/new) for answers from GitHub trainers!
 {: .notice--success}

--- a/_includes/activity/gh-pages/03-create-new-page.md
+++ b/_includes/activity/gh-pages/03-create-new-page.md
@@ -15,5 +15,5 @@ Time to add our work history as a page to our Jekyll site.
   {{ activity-text | markdownify }}
 </div>
 
-Need help? Click **open chat** below for answers from GitHub trainers!
+Need help? **Open an issue** [in our class repository](https://github.com/githubschool/on-demand-github-pages/issues/new) for answers from GitHub trainers!
 {: .notice--success}

--- a/_includes/activity/gh-pages/04-more-content.md
+++ b/_includes/activity/gh-pages/04-more-content.md
@@ -24,5 +24,5 @@ You might also look into the "collections" functionality in Jekyll. This would l
   {{ activity-text | markdownify }}
 </div>
 
-Need help? Click **open chat** below for answers from GitHub trainers!
+Need help? **Open an issue** [in our class repository](https://github.com/githubschool/on-demand-github-pages/issues/new) for answers from GitHub trainers!
 {: .notice--success}

--- a/_includes/help-build-fail.md
+++ b/_includes/help-build-fail.md
@@ -6,7 +6,7 @@ The files we are using are very picky. If you made any mistakes, you will see a 
 
 When you commit your changes, Travis CI will re-check your file.
 
-Keep doing this until you see a message that the build has passed. If you need help, don't forget you can find us in chat or @ mention `@githubteacher` in your pull request.
+Keep doing this until you see a message that the build has passed. If you need help, don't forget you can @ mention `@githubteacher` in your pull request.
 
 ### Help With Specific Issues
 

--- a/_layouts/intro-to-github.html
+++ b/_layouts/intro-to-github.html
@@ -20,12 +20,6 @@ sidebar:
 {% endif %}
 
 <div id="main" role="main">
-  <script>
-    ((window.gitter = {}).chat = {}).options = {
-      room: 'githubschool/on-demand'
-    };
-  </script>
-  <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
 
   {% include sidebar.html %}
 

--- a/_layouts/simple-class.html
+++ b/_layouts/simple-class.html
@@ -12,12 +12,6 @@ header:
 {% endif %}
 
 <div id="main" role="main">
-  <script>
-    ((window.gitter = {}).chat = {}).options = {
-      room: 'githubschool/on-demand'
-    };
-  </script>
-  <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
 
   {% include sidebar.html %}
 
@@ -153,7 +147,7 @@ header:
         {% endif %}
 
         <div class="notice--success">
-        Need help? Click <b>open chat</b> below for answers from GitHub trainers!
+        Need help? Just mention @githubteacher for help from one of the GitHub trainers!
         </div>
 
         {% if page.next-page %}

--- a/community.md
+++ b/community.md
@@ -17,7 +17,7 @@ In the meantime, a great way to learn new things is to explain them to others. I
 
 ## GitHub Trainers
 
-Meet the members of GitHub who will be in Gitter and the class repository helping you along the way.
+Meet the members of GitHub who will be dropping by the class repository and helping you along the way.
 
 | ![@beardofedu](https://avatars2.githubusercontent.com/u/18329853?v=3&s=140){: .align-center}|![@brianamarie](https://avatars0.githubusercontent.com/u/9906718?v=3&s=140){: .align-center}|![@crichID](https://avatars0.githubusercontent.com/u/9950121?v=3&s=140){: .align-center}|![@hectorsector](https://avatars3.githubusercontent.com/u/16547949?v=3&s=140){: .align-center}|![@hollenberry](https://avatars1.githubusercontent.com/u/13326548?v=3&s=140){: .align-center}|
 |---|---|---|---|---|

--- a/community.md
+++ b/community.md
@@ -9,18 +9,11 @@ header:
 
 # Availability
 
-GitHub's training team answers your questions about this training via a Gitter chat room. Gitter is a chat service that integrates well with GitHub and allows you to authenticate with your GitHub account.
+GitHub's training team drops by the on-demand repositories daily to answer questions and offer assistance to those who are stuck.
 
  We will work to answer questions within 12 hours if you ask them Monday through Friday (except on [US holidays](us-holidays/)).
 
-In the meantime, a great way to learn new things is to explain them to others. If you see any questions you feel equipped to answer, please feel free to help!
-
- Just use the "Open Chat" button on the bottom right of your browser when you begin working through the exercises.  
-
-If you aren't quite ready to get started yet, but want to bookmark the "Help" room, you can find us here:
-
-[Chat on Gitter](https://gitter.im/githubschool/on-demand?utm_source=share-link&utm_medium=link&utm_campaign=share-link){: .btn .btn--success}
-
+In the meantime, a great way to learn new things is to explain them to others. If you see any questions you feel equipped to answer, please feel free to help!  
 
 ## GitHub Trainers
 

--- a/paths/intro-to-github/12-celebrate.md
+++ b/paths/intro-to-github/12-celebrate.md
@@ -39,7 +39,7 @@ main-content: |
 
   ### Keep learning
 
-  The GitHub Training team offers free open enrollment classes every month. Just visit the [GitHub Training](https://services.github.com/training/) site to enroll in our next live webinar.
+  The GitHub Training team offers free webinars and full courses every month. Just visit the [GitHub Training](https://services.github.com/training/) site to enroll in our next course.
 show-me-how:
 tell-me-why:
 ---

--- a/paths/intro-to-github/12-celebrate.md
+++ b/paths/intro-to-github/12-celebrate.md
@@ -35,7 +35,7 @@ main-content: |
 
   ### Help Others
 
-  Just because you have finished this exercise, doesn't mean you have to leave. Feel free to drop in to the Gitter chat room anytime and help other learners who are completing the class. Or, drop an encouraging note in an old pull request. You might just be the reason they finish!
+  Just because you have finished this exercise, doesn't mean you have to leave. Feel free to drop in to open Issues anytime and help other learners who are completing the class. Or, drop an encouraging note in an old pull request. You might just be the reason they finish!
 
   ### Keep learning
 


### PR DESCRIPTION
## Overview
**TL;DR**
This PR removes the Chat option from on-demand. 

### Why

The chat option was always an experiment to see how many users would drop in and request help. After having the option available for ~ 1 year, we have found that a very small number of students use it. Most of these students also requested help in a GitHub issue or pull request, making chat redundant. 

This PR removes the chat option and attempts to reinforce the :+1: behavior of asking questions and requesting help in issues and pull requests.

### Next Steps
- [x] Get :eyes: from @hectorsector to make sure I removed everything that needed to be removed
- [x] :ship: it

/FYI @github/services-training for updates to comms
