### PR TITLE
Remove desktop references from windows

### DIFF
--- a/paths/windows/01a-installing-git.md
+++ b/paths/windows/01a-installing-git.md
@@ -9,12 +9,9 @@ next-page: /windows/configure-git
 sidebar:
   nav: "windows"
 main-content: |
-  Installing Git on your Windows computer is relatively straightforward. You can either download Git from git-scm or install the GUI Git platform built with :heart: by GitHub, GitHub Desktop. 
+  Installing Git on your Windows computer is relatively straightforward. You can download Git directly from git-scm.
 
   - [git-scm](https://git-scm.com/downloads)
      - [git-scm Windows Install Guide](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - [GitHub Desktop](https://desktop.github.com/)
-     - [GitHub Desktop Installation Instructions](https://help.github.com/desktop/guides/getting-started/installing-github-desktop/#platform-windows)
-     - [GitHub Desktop Getting Started Guide](https://help.github.com/desktop/guides/getting-started/)
 
 ---

--- a/paths/windows/03e-sync.md
+++ b/paths/windows/03e-sync.md
@@ -19,12 +19,6 @@ main-content: |
     - **pull** - performs a `git pull`.
     - **push** - performs a `git push`.
 
-  ## GitHub Desktop
-  The **Sync** button is located in the top right corner of the GitHub Desktop GUI and provides you an opportunity to share the commits you have made locally with your remote repository as well as `pull` any commits other collaborators have made to your project.
-
-  - First, a `git pull` is performed to retrieve the latest changes from your remote (or hosted) git repository.`
-  - Second, a `git push` is performed, which sends all of the `commit`s you made locally to your remote git repository.
-
 tell-me-why: |
   One of the primary reasons to use a collaborative version control system like Git is the ability to collaborate with other people on your project and 'syncing' allows you to share the changes you have made with those other collaborators. In a typical workflow, after making `commit`s to your project, you should be `push`ing those `commit`s to your remote repository.
 


### PR DESCRIPTION
## Overview

With the release of the new Electron based Desktop application, Git will no longer be installed with Desktop. It will now prompt the user to download and install Git from git-scm.com. As a result, this PR removes the Desktop reference on the installing git page.

Also, the `Sync` button has changed in Desktop. Rather than deal with the complexity here, I removed it from the VS section since it was also the only other reference to Desktop in the course.

### Questions

- [x] @beardofedu are you :+1: with these changes?
- [x] Requesting :eyes: and :+1:/:-1: from a member of @github/services-training