### PR TITLE
Clean up instructions for exiting VI

### DIFF
--- a/_includes/activity/github-CLI/05-make-commits.md
+++ b/_includes/activity/github-CLI/05-make-commits.md
@@ -6,6 +6,6 @@ Your file is listed under the heading _Untracked files_.
 1. Type `git status` again to see what has changed. Your file is now listed under the heading _Changes to be committed_. This tells us that the file is in the staging area. It also indicates this is a new file.
 1. Type `git commit`. This tells git to collect all of the files in the staging area and commit them to version control as a single unit of work. Git will open your default text editor where you can enter the commit message.
 1. Type the commit message, save and quit your editor.
-    - The default text editor associated with git is `vi` in most cases, which requires that you type `:wq` to save and quit after entering your commit message.
+    - The default text editor associated with git is `vi` in most cases, which requires that you press the `Esc` key then type `:wq` to save and quit after entering your commit message.
     - Alternatively, you can bypass `vi` altogether and enter your commit message inline with `git commit -m "your message"`
 1. To see the history of commits, type `git log`.


### PR DESCRIPTION
This error occurs on the the following [page](https://services.github.com/on-demand/github-cli/add-commits-git), Step 5, bullet 1.
 
This was brought to our attention during the Nashville Patchwork. Shoutout to @crichID

## Overview
**TL;DR**
Directions to leave VI didn't include a reference to the `Esc` key, and now it does.

<Link to related issue. Type `closes #RELATEDISSUENUMBER` to establish a link.>

### Review
👀  @crichID @hectorsector @brianamarie 

Looking for 1 👍  to 🚢 