### PR TITLE
Change courses to include GitHub Pages reference in title

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,9 +3,9 @@ main:
 # Keep original nav, do not replace
   - title: "Introduction to GitHub"
     url: /intro-to-github/
-  - title: "Using GitHub Desktop"
+  - title: "GitHub Pages from GitHub Desktop"
     url: /github-desktop/
-  - title: "Using the Command Line"
+  - title: "GitHub Pages from the Command Line"
     url: /github-cli/
   - title: "Git Out of Trouble"
     url: /git-trouble/

--- a/_includes/timeline.html
+++ b/_includes/timeline.html
@@ -61,7 +61,7 @@
                             </div>
                             <div class="timeline-panel">
                                 <div class="timeline-heading">
-                                    <a href="/on-demand/github-desktop/"><h2>GitHub 102: Using GitHub Desktop</h2></a>
+                                    <a href="/on-demand/github-desktop/"><h2>GitHub 102: GitHub Pages from GitHub Desktop</h2></a>
                                 </div>
                                 <div class="timeline-body">
                                     <p class="text-muted">Learn how to <b>use GitHub Desktop</b> to copy a repository to your computer, track changes and communicate with GitHub.</p>
@@ -80,7 +80,7 @@
                             </div>
                             <div class="timeline-panel">
                                 <div class="timeline-heading">
-                                    <a href="/on-demand/github-cli/"><h2>GitHub 103: Using the Command Line</h2></a>
+                                    <a href="/on-demand/github-cli/"><h2>GitHub 103: GitHub Pages from the Command Line</h2></a>
                                 </div>
                                 <div class="timeline-body">
                                         <p class="text-muted">Learn how to <b>use the Command Line</b> to copy a repository to your computer, track changes and communicate with GitHub.</p>

--- a/paths/github-cli/01-github-CLI-introduction.md
+++ b/paths/github-cli/01-github-CLI-introduction.md
@@ -3,7 +3,7 @@ layout: simple-class
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)
-title: GitHub Pages & Git in the Command Line
+title: GitHub Pages from the Command Line
 permalink: /github-cli/
 next-page: /github-cli/git-configuration
 facilitator: false

--- a/paths/github-desktop/01-class-introduction.md
+++ b/paths/github-desktop/01-class-introduction.md
@@ -3,7 +3,7 @@ layout: simple-class
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)
-title: GitHub Pages & GitHub Desktop
+title: GitHub Pages from GitHub Desktop
 permalink: /github-desktop/
 next-page: /github-desktop/install-github-desktop
 facilitator: false


### PR DESCRIPTION
## Overview
**TL;DR**

As GitHub Pages is a frequently searched term, I've modified the course title to include GitHub Pages and the specific interface used to interact with Git and GitHub. 

### Questions

- Do people think this change looks 👍 ?

### Next Steps

- [x] Quick run through of the internal contents of the class to make sure the course title isn't referenced. 

### Review

I will ping once I have given the content a quick once over. 
