### PR TITLE
remove converting apps from nav

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -193,10 +193,6 @@ electron-getting-started:
   - title: "Creating an App"
     url: /electron/starting-with-electron/
 
-electron-converting-apps:
-- title: "Converting Apps"
-  url: /electron/converting-apps/
-
 electron-packaging-apps:
   - title: "Packaging Apps"
     url: /electron/packaging-apps/


### PR DESCRIPTION
removing the 'converting apps' section from the navigation