### PR TITLE
start outline for packaging apps

### DIFF
--- a/paths/electron/packaging-apps/outline.md
+++ b/paths/electron/packaging-apps/outline.md
@@ -6,7 +6,7 @@ Main goal: Going from local to something someone can download
 Maybe usign something like this video to help us: https://www.youtube.com/watch?v=GC3oMVdnmVg
 - Packaging from Mac to Mac
 - Packaging from Mac to Linux
-- Packaging from Mac to Windows (I needed to `brew cask install xquartz`, and `brew install wine`)
+- Packaging from Mac to Windows (I needed to `brew cask install xquartz`, and `brew install wine`, and was prompted to install a wine mono package from a website which I did but don't know if it was necessary)
 - Packaging from Windows to Mac
 - Packaging from Windows to Linux
 - etc...?

--- a/paths/electron/packaging-apps/outline.md
+++ b/paths/electron/packaging-apps/outline.md
@@ -1,3 +1,20 @@
-## Learning goals
+# Electron 102: Packaging Electron Apps
 
-Take a locally running app, and package it up to be downloaded natively on other computers
+Main goal: Going from local to something someone can download
+
+## Packaging for different environments
+- Needs for Windows, OSX, and Linux
+- Packaging can be done for each OS, but the UI isn't automatically made to look native in the process
+
+## Tools to use
+- How to do this with Electron
+- Other libraries to use
+
+## Adding an Icon
+- Including the icon image for the program 
+
+## Common Challenges
+- Problems that come up
+
+## Testing that the packages work
+- How to test the packages

--- a/paths/electron/packaging-apps/outline.md
+++ b/paths/electron/packaging-apps/outline.md
@@ -5,19 +5,26 @@ Main goal: Going from local to something someone can download
 ## Packaging for different environments
 - Needs for Windows, OSX, and Linux
 - Packaging can be done for each OS, but the UI isn't automatically made to look native in the process
+- Many factors make this somewhat complicated. It is a different process based on your OS and the OS you're trying to go to.
 
 ## Tools to use
-- How to do this with Electron
-- Other libraries to use
+Q: What is the recommended way to do this?
+- [How to do this with Electron](https://github.com/electron/electron/blob/master/docs/tutorial/application-packaging.md)
+- [Other libraries to use](https://github.com/electron-userland/electron-packager)
 
 ## Adding an Icon
-- Including the icon image for the program 
+- Including the icon image for the program
 - give recommendations on what type of image is allowed (open or public domain) and what size would be best.
 - possibly include [icon library](https://useiconic.com/open) suggestions
+
+## Walkthrough of Process
+- Detailed walkthrough of the tutorial?
+- Include video/gifs?
+- Versioning apps?
 
 ## Common Challenges
 - Problems that come up
 
 ## Testing that the packages work
 - How to test the packages
-- Allude to automated testing but probably not walk through it 
+- Allude to automated testing but probably not walk through it

--- a/paths/electron/packaging-apps/outline.md
+++ b/paths/electron/packaging-apps/outline.md
@@ -12,9 +12,12 @@ Main goal: Going from local to something someone can download
 
 ## Adding an Icon
 - Including the icon image for the program 
+- give recommendations on what type of image is allowed (open or public domain) and what size would be best.
+- possibly include [icon library](https://useiconic.com/open) suggestions
 
 ## Common Challenges
 - Problems that come up
 
 ## Testing that the packages work
 - How to test the packages
+- Allude to automated testing but probably not walk through it 

--- a/paths/electron/packaging-apps/outline.md
+++ b/paths/electron/packaging-apps/outline.md
@@ -8,19 +8,24 @@ Main goal: Going from local to something someone can download
 - Many factors make this somewhat complicated. It is a different process based on your OS and the OS you're trying to go to.
 
 ## Tools to use
-Q: What is the recommended way to do this?
 - [How to do this with Electron](https://github.com/electron/electron/blob/master/docs/tutorial/application-packaging.md)
 - [Other libraries to use](https://github.com/electron-userland/electron-packager)
+
+
+## Walkthrough of Process from Mac
+Do we want to do this from Windows, too?
+- `npm i electron-packager --save-dev`
+- Add build script `"build": "electron-packager . app-name"` in "scripts" of package.json
+- `npm run build`
+
 
 ## Adding an Icon
 - Including the icon image for the program
 - give recommendations on what type of image is allowed (open or public domain) and what size would be best.
 - possibly include [icon library](https://useiconic.com/open) suggestions
-
-## Walkthrough of Process
-- Detailed walkthrough of the tutorial?
-- Include video/gifs?
-- Versioning apps?
+- Replace icon in Contents>Resources directory in build script: "build": "electron-packager . app-name && cp Icon.icns Path/To/New/Icon"
+- Delete app: `rm -rf AppName.app`
+- Rebuild: `npm run build`
 
 ## Common Challenges
 - Problems that come up

--- a/paths/electron/packaging-apps/outline.md
+++ b/paths/electron/packaging-apps/outline.md
@@ -2,6 +2,14 @@
 
 Main goal: Going from local to something someone can download
 
+?? Do we need to have diffferent guides here?
+- Packaging from Mac to Mac
+- Packaging from Mac to Linux
+- Packaging from Mac to Windows
+- Packaging from Windows to Mac
+- Packaging from Windows to Linux
+- etc...? 
+
 ## Packaging for different environments
 - Needs for Windows, OSX, and Linux
 - Packaging can be done for each OS, but the UI isn't automatically made to look native in the process
@@ -12,10 +20,10 @@ Main goal: Going from local to something someone can download
 - [Other libraries to use](https://github.com/electron-userland/electron-packager)
 
 
-## Walkthrough of Process from Mac
+# Walkthrough of Process from Mac to Mac
 Do we want to do this from Windows, too?
-- `npm i electron-packager --save-dev`
-- Add build script `"build": "electron-packager . app-name"` in "scripts" of package.json
+- `npm install electron-packager --save-dev`
+- Add build script `"build": "electron-packager . app-name --ignore=node_modules/electron-*"` in "scripts" of package.json (ignore all dependency apps the same way)
 - `npm run build`
 
 
@@ -26,6 +34,12 @@ Do we want to do this from Windows, too?
 - Replace icon in Contents>Resources directory in build script: "build": "electron-packager . app-name && cp Icon.icns Path/To/New/Icon"
 - Delete app: `rm -rf AppName.app`
 - Rebuild: `npm run build`
+
+## Stopping people from editing source code with asar
+- Archive capability with asar
+- `npm install asar --save-dev`
+- Create another script in package.json called "package": "asar pack AppName.app/Contents/Resources/app MyApp.app/Contents/Resources/app.assar"
+- Run `npm package`, and delete the app directory
 
 ## Common Challenges
 - Problems that come up

--- a/paths/electron/packaging-apps/outline.md
+++ b/paths/electron/packaging-apps/outline.md
@@ -3,12 +3,13 @@
 Main goal: Going from local to something someone can download
 
 ?? Do we need to have diffferent guides here?
+Maybe usign something like this video to help us: https://www.youtube.com/watch?v=GC3oMVdnmVg
 - Packaging from Mac to Mac
 - Packaging from Mac to Linux
 - Packaging from Mac to Windows
 - Packaging from Windows to Mac
 - Packaging from Windows to Linux
-- etc...? 
+- etc...?
 
 ## Packaging for different environments
 - Needs for Windows, OSX, and Linux

--- a/paths/electron/packaging-apps/outline.md
+++ b/paths/electron/packaging-apps/outline.md
@@ -6,7 +6,7 @@ Main goal: Going from local to something someone can download
 Maybe usign something like this video to help us: https://www.youtube.com/watch?v=GC3oMVdnmVg
 - Packaging from Mac to Mac
 - Packaging from Mac to Linux
-- Packaging from Mac to Windows
+- Packaging from Mac to Windows (I needed to `brew cask install xquartz`, and `brew install wine`)
 - Packaging from Windows to Mac
 - Packaging from Windows to Linux
 - etc...?
@@ -48,3 +48,5 @@ Do we want to do this from Windows, too?
 ## Testing that the packages work
 - How to test the packages
 - Allude to automated testing but probably not walk through it
+
+## Using electron-packager, how to clean up old binaries and what that means


### PR DESCRIPTION
This pull request brings the first draft of the 'packaging' course for electron into the `electron-course` branch. 

I'm not sure exactly how these sections map out to the questions we want to answer and the workflow we want to advise, but I'm hoping we can get more detailed as we go along. 

cc @github/services-training and @leefaus for review and edits
