### PR TITLE
Electron draft: Sharing and Distributing apps

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -199,4 +199,8 @@ electron-packaging-apps:
 
 electron-sharing-apps:
   - title: "Sharing Apps"
-    url: /electron/starting-with-electron/
+    url: /electron/distributing-apps/
+  - title: "Native App Discovery"
+    url: /electron/distributing-apps/native-app-discovery
+  - title: "Sharing on Websites"
+    url: /electron/distributing-apps/sharing-on-websites

--- a/paths/electron/distributing/01-share-apps.md
+++ b/paths/electron/distributing/01-share-apps.md
@@ -11,8 +11,15 @@ sidebar:
   nav: "electron-sharing-apps"
 main-content: |
 
-  Content here
-  
+
+  So I have a packaged app, now what? How to get apps onto the app store and easy to download.
+
+
+  ## Legal things to be aware of
+  - Once you're sharing your app, your licenses and other legal things need to be in order
+     - App submission checklist for Windows (https://docs.microsoft.com/en-us/windows/uwp/publish/app-submissions)
+
+
 show-me-how:
 tell-me-why:
 

--- a/paths/electron/distributing/01-share-apps.md
+++ b/paths/electron/distributing/01-share-apps.md
@@ -11,14 +11,13 @@ sidebar:
   nav: "electron-sharing-apps"
 main-content: |
 
+  ## Sharing Electron Applications
 
-  So I have a packaged app, now what? How to get apps onto the app store and easy to download.
+  So you have a packaged app, but now what? The next few pages will walk through how to make apps easy to find and download. However, we the source of truth should always be this [documentation on application distribution](https://github.com/electron/electron/blob/master/docs/tutorial/application-distribution.md).
 
+  ### Legal things to be aware of
 
-  ## Legal things to be aware of
-  - Once you're sharing your app, your licenses and other legal things need to be in order
-     - App submission checklist for Windows (https://docs.microsoft.com/en-us/windows/uwp/publish/app-submissions)
-
+  Once you're sharing your app, your licenses and other legal things need to be in order. We recommend [this article](https://help.github.com/articles/licensing-a-repository/) to help you choose the right license for your project.
 
 show-me-how:
 tell-me-why:

--- a/paths/electron/distributing/01-share-apps.md
+++ b/paths/electron/distributing/01-share-apps.md
@@ -4,8 +4,8 @@ header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)
 title: Sharing Electron Apps
-permalink: /electron/sharing-apps/
-next-page: /electron/sharing-apps/
+permalink: /electron/distributing-apps/
+next-page: /electron/distributing-apps/native-app-discovery
 facilitator: false
 sidebar:
   nav: "electron-sharing-apps"

--- a/paths/electron/distributing/02-native-app-discovery.md
+++ b/paths/electron/distributing/02-native-app-discovery.md
@@ -12,10 +12,20 @@ sidebar:
 main-content: |
 
   ## Native App Discovery
-  - [General docs on application distribution](https://github.com/electron/electron/blob/master/docs/tutorial/application-distribution.md)
-  - Apple has app store...[See Mac App Store Submission Guide](https://github.com/electron/electron/blob/master/docs/tutorial/mac-app-store-submission-guide.md)
-  - Windows has the [Windows Store]( (https://www.microsoft.com/en-US/store/apps?rtc=1))...[See Windows Store Guide](https://github.com/electron/electron/blob/master/docs/tutorial/windows-store-guide.md)
-  - Linux has Ubuntu Apps Directory (https://apps.ubuntu.com/cat/) and Deepin App Store (http://appstore.deepin.com/)
+
+  Here are some resources for sharing the apps in their native stores. However, instead of walking through this process with the app we built earlier, we'll show you these resources and move on to a how-to of getting the app up and ready for download from a website. 
+
+  ### Apple
+  - Apple has the App Store. Read up on [Electron's guide for Mac App Store Submission](https://github.com/electron/electron/blob/master/docs/tutorial/mac-app-store-submission-guide.md), or Apple's own [guide](
+  https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/SubmittingYourApp/SubmittingYourApp.html
+).
+
+  ### Windows
+  - Windows has the [Windows Store]( (https://www.microsoft.com/en-US/store/apps?rtc=1)). You can [see the Windows Store Guide here](https://github.com/electron/electron/blob/master/docs/tutorial/windows-store-guide.md), and look at the [application submission checklist for Windows here](https://docs.microsoft.com/en-us/windows/uwp/publish/app-submissions).
+
+  ### Linux
+  - Linux has [Ubuntu Apps Directory](https://apps.ubuntu.com/cat/) and [Deepin App Store](http://appstore.deepin.com/).
+
 
 show-me-how:
 tell-me-why:

--- a/paths/electron/distributing/02-native-app-discovery.md
+++ b/paths/electron/distributing/02-native-app-discovery.md
@@ -3,9 +3,9 @@ layout: simple-class
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)
-title: Sharing Electron Apps
-permalink: /electron/sharing-apps/
-next-page: /electron/sharing-apps/
+title: Native App Discovery
+permalink: /electron/distributing-apps/native-app-discovery
+next-page: /electron/distributing-apps/sharing-on-websites
 facilitator: false
 sidebar:
   nav: "electron-sharing-apps"

--- a/paths/electron/distributing/02-native-app-discovery.md
+++ b/paths/electron/distributing/02-native-app-discovery.md
@@ -11,8 +11,12 @@ sidebar:
   nav: "electron-sharing-apps"
 main-content: |
 
-  Content here
-  
+  ## Native App Discovery
+  - [General docs on application distribution](https://github.com/electron/electron/blob/master/docs/tutorial/application-distribution.md)
+  - Apple has app store...[See Mac App Store Submission Guide](https://github.com/electron/electron/blob/master/docs/tutorial/mac-app-store-submission-guide.md)
+  - Windows has the [Windows Store]( (https://www.microsoft.com/en-US/store/apps?rtc=1))...[See Windows Store Guide](https://github.com/electron/electron/blob/master/docs/tutorial/windows-store-guide.md)
+  - Linux has Ubuntu Apps Directory (https://apps.ubuntu.com/cat/) and Deepin App Store (http://appstore.deepin.com/)
+
 show-me-how:
 tell-me-why:
 

--- a/paths/electron/distributing/02-native-app-discovery.md
+++ b/paths/electron/distributing/02-native-app-discovery.md
@@ -1,0 +1,19 @@
+---
+layout: simple-class
+header:
+  overlay_image: cover.jpeg
+  overlay_filter: rgba(46, 129, 200, 0.6)
+title: Sharing Electron Apps
+permalink: /electron/sharing-apps/
+next-page: /electron/sharing-apps/
+facilitator: false
+sidebar:
+  nav: "electron-sharing-apps"
+main-content: |
+
+  Content here
+  
+show-me-how:
+tell-me-why:
+
+---

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -19,6 +19,8 @@ main-content: |
 
   For now, let's walk through the steps of uploading the packaged application to be a GitHub release.
 
+  TODO - do we want to walk through the steps here, or just link out to [this help doc](https://help.github.com/articles/creating-releases/)?
+  
 show-me-how:
 tell-me-why:
 

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -11,8 +11,10 @@ sidebar:
   nav: "electron-sharing-apps"
 main-content: |
 
-  Content here
-  
+  ## Downloads from a website, how to set up a website so others can download a program by clicking a button
+
+  - Show how to get the packaged app onto existing website (maybe pages? linking to release package? would we need something heftier?)
+
 show-me-how:
 tell-me-why:
 

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -1,0 +1,19 @@
+---
+layout: simple-class
+header:
+  overlay_image: cover.jpeg
+  overlay_filter: rgba(46, 129, 200, 0.6)
+title: Sharing Electron Apps
+permalink: /electron/sharing-apps/
+next-page: /electron/sharing-apps/
+facilitator: false
+sidebar:
+  nav: "electron-sharing-apps"
+main-content: |
+
+  Content here
+  
+show-me-how:
+tell-me-why:
+
+---

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -3,9 +3,8 @@ layout: simple-class
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)
-title: Sharing Electron Apps
-permalink: /electron/sharing-apps/
-next-page: /electron/sharing-apps/
+title: Sharing on Websites
+permalink: /electron/distributing-apps/sharing-on-websites
 facilitator: false
 sidebar:
   nav: "electron-sharing-apps"

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -13,12 +13,11 @@ main-content: |
   ## Preparing Electron Apps for Download
 
 
-  Most commonly, electron apps are shared via [GitHub Releases](). People who create and package their own applications upload the binaries to a GitHub repository where others can download them. You can see some great examples of this on the [electron app page](). This is free, version controlled, and kept cleanly alongside your code.
+  Most commonly, electron apps are shared via [GitHub Releases](https://help.github.com/articles/about-releases/). People who create and package their own applications upload the binaries to a GitHub repository where others can download them. You can see some great examples of this on the [electron app page](https://electron.atom.io/apps/). This is free, version controlled, and kept cleanly alongside your code.
 
-  You could then link to your downloads from your very own [GitHub pages site](), or any site for that matter. [Learn how to make your own GitHub Pages site here]().
+  You could then link to your downloads from your very own [GitHub pages site](https://pages.github.com/), or any site for that matter. [Learn how to make your own GitHub Pages site here](https://services.github.com/on-demand/github-cli/).
 
   For now, let's walk through the steps of uploading the packaged application to be a GitHub release.
-
 
 show-me-how:
 tell-me-why:

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -20,7 +20,7 @@ main-content: |
   For now, let's walk through the steps of uploading the packaged application to be a GitHub release.
 
   TODO - do we want to walk through the steps here, or just link out to [this help doc](https://help.github.com/articles/creating-releases/)?
-  
+
 show-me-how:
 tell-me-why:
 

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -10,9 +10,11 @@ sidebar:
   nav: "electron-sharing-apps"
 main-content: |
 
-  ## Downloads from a website, how to set up a website so others can download a program by clicking a button
+  ## Preparing Electron Apps for Download
 
-  - Show how to get the packaged app onto existing website (maybe pages? linking to release package? would we need something heftier?)
+  - Can GitHub Pages work? GitHub releases?
+  - Type of website needed
+  - Hosting 
 
 show-me-how:
 tell-me-why:

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -12,9 +12,13 @@ main-content: |
 
   ## Preparing Electron Apps for Download
 
-  - Can GitHub Pages work? GitHub releases?
-  - Type of website needed
-  - Hosting 
+
+  Most commonly, electron apps are shared via [GitHub Releases](). People who create and package their own applications upload the binaries to a GitHub repository where others can download them. You can see some great examples of this on the [electron app page](). This is free, version controlled, and kept cleanly alongside your code.
+
+  You could then link to your downloads from your very own [GitHub pages site](), or any site for that matter. [Learn how to make your own GitHub Pages site here]().
+
+  For now, let's walk through the steps of uploading the packaged application to be a GitHub release.
+
 
 show-me-how:
 tell-me-why:

--- a/paths/electron/distributing/outline.md
+++ b/paths/electron/distributing/outline.md
@@ -2,21 +2,18 @@
 
 So I have a packaged app, now what? How to get apps onto the app store and easy to download.
 
+
+## Legal things to be aware of
+- Once you're sharing your app, your licenses and other legal things need to be in order
+   - App submission checklist for Windows (https://docs.microsoft.com/en-us/windows/uwp/publish/app-submissions)
+
+
 ## Native App Discovery
 - [General docs on application distribution](https://github.com/electron/electron/blob/master/docs/tutorial/application-distribution.md)
 - Apple has app store...[See Mac App Store Submission Guide](https://github.com/electron/electron/blob/master/docs/tutorial/mac-app-store-submission-guide.md)
 - Windows has the [Windows Store]( (https://www.microsoft.com/en-US/store/apps?rtc=1))...[See Windows Store Guide](https://github.com/electron/electron/blob/master/docs/tutorial/windows-store-guide.md)
 - Linux has Ubuntu Apps Directory (https://apps.ubuntu.com/cat/) and Deepin App Store (http://appstore.deepin.com/)
 
-## Legal things to be aware of
-- Once you're sharing your app, your licenses and other legal things need to be in order
-   - App submission checklist for Windows (https://docs.microsoft.com/en-us/windows/uwp/publish/app-submissions)
+## Downloads from a website, how to set up a website so others can download a program by clicking a button
 
-## Walkthrough of general app distribution process outlined and supported by Electron
-
-## Downloads from a website
 - Show how to get the packaged app onto existing website (maybe pages? linking to release package? would we need something heftier?)
-
-### How to set up a website so others can download a program by clicking a button
-
-### Once downloaded, have app go to the local directory that is expected on that OS


### PR DESCRIPTION
## Overview
**TL;DR**
This pull request is for the draft of the third course in the [Electron path](https://github.com/github/training-kit/projects/2), Sharing Apps.

### Questions
- Does this course cover the right amount of breadth and depth? 
- Is the native app info accurate?
- Can GitHub Pages work for hosting apps? 
- Would GitHub releases work for hosting apps?
- If not GitHub pages, what type of website is needed?
- What other hosting is recommended?

### Next Steps
- ✏️ @github/services-training to fill in content 
- 💻 @github/services-training to test the activity
- 👍 and 💭 from @lee-dohm if we are moving in the right direction 

### Review
Not yet ready for review.

  