### PR TITLE
Update electron-forge install so it does not install globally

### DIFF
--- a/paths/electron/starting-with-electron/02-electron-boilerplate.md
+++ b/paths/electron/starting-with-electron/02-electron-boilerplate.md
@@ -20,7 +20,7 @@ main-content: |
   ![gif of following the directions below](<% SITEURL %><% BASEURL %>/images/gifs/electron/electron1-createapp.gif)
 
   1. Find the terminal and navigate to your desired project location, for example: `cd ~/` will navigate to your home directory.
-  1. Install electron-forge globally: `npm install -g electron-forge`
+  1. Install electron-forge globally: `npm install electron-forge`
   1. Initialize a new project: `electron-forge init electron-app`
   1. Change into that app's directory: `cd electron-app`
 


### PR DESCRIPTION
## Overview
This pull request updates the instructions for installing `electron-forge` so that it is not installed globally. This is now possible after [electron-forge](https://github.com/electron-userland/electron-forge/pull/296)'s update. 

Shoutout and thanks to @zeke, @malept, and @MarshallOfSound for making this change in `electron-forge`. ❤️ 

### Next Steps
- [ ] Verify this syntax is correct 
- [ ] Update the gif 

### Review
@github/services-training, @zeke, @malept, @MarshallOfSound, does this look correct? 