### PR TITLE
Change labels for git cheat sheets to be in language that they are in

### DIFF
--- a/resources/cheatsheets/index.html
+++ b/resources/cheatsheets/index.html
@@ -23,25 +23,27 @@ redirect_from:
           {% include icon-sm-git.svg %}
           <h3 class="display-heading-3">Using Git</h3>
           <ul>
-            <li><a href="{{ site.baseurl }}/downloads/ar/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Arabic"></span> عربى</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/bn_BD/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Bengali"></span> বাঙালি</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/zh_CN/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Chinese"></span> 中文</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/fr/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download French"></span> Français</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download French"></span> Français (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/de/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download German"></span> Deutsche</a></li>
             <li><a href="{{ site.baseurl }}/downloads/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download English"></span> English</a></li>
             <li><a href="{{ site.baseurl }}/downloads/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download English"></span> English (PDF)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/de/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download German"></span> Deutsche</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/es_ES/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Spanish"></span> Español</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/es_ES/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Spanish"></span> Español (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/fr/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download French"></span> Français</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download French"></span> Français (PDF)</a></li>
             <li><a href="{{ site.baseurl }}/downloads/it/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Italian"></span> Italiano</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/ja/github-git-cheat-sheet"><span class="octicon octicon-cloud-download Japanese"></span> 日本語</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Japanese"></span> 日本語 (PDF)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/kr/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Korean"></span> 한국어</a></li>
             <li><a href="{{ site.baseurl }}/downloads/pt_BR/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Portuguese Brazil"></span> Português (Brasil)</a></li>
             <li><a href="{{ site.baseurl }}/downloads/pt_BR/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Portuguese Brazil"></span> Português (Brasil) (PDF)</a></li>
             <li><a href="{{ site.baseurl }}/downloads/pt_PT/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Portuguese Portugal"></span> Português (Portugal)</a></li>
             <li><a href="{{ site.baseurl }}/downloads/pt_PT/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Portuguese Portugal"></span> Português (Portugal) (PDF)</a></li>
             <li><a href="{{ site.baseurl }}/downloads/sk/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Slovak"></span> Slovenský</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/es_ES/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Spanish"></span> Español</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/es_ES/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Spanish"></span> Español (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/ar/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Arabic"></span> عربى</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/bn_BD/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Bengali"></span> বাঙালি</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/kr/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Korean"></span> 한국어</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/zh_CN/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Chinese"></span> 中文</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/ja/github-git-cheat-sheet"><span class="octicon octicon-cloud-download Japanese"></span> 日本語</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Japanese"></span> 日本語 (PDF)</a></li>
+
+
           </ul>
         </div>
         <div class="cheat-sheet">

--- a/resources/cheatsheets/index.html
+++ b/resources/cheatsheets/index.html
@@ -23,25 +23,25 @@ redirect_from:
           {% include icon-sm-git.svg %}
           <h3 class="display-heading-3">Using Git</h3>
           <ul>
-            <li><a href="{{ site.baseurl }}/downloads/ar/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Arabic</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/bn_BD/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Bengali</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/zh_CN/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Chinese</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/fr/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> French</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> French (PDF)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> English</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> English (PDF)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/de/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> German</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/it/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Italian</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/ja/github-git-cheat-sheet"><span class="octicon octicon-cloud-download"></span> Japanese</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Japanese (PDF)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/kr/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Korean</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/pt_BR/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Portuguese (Brazil)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/pt_BR/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Portuguese (Brazil) (PDF)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/pt_PT/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Portuguese (Portugal)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/pt_PT/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Portuguese (Portugal) (PDF)</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/sk/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Slovak</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/es_ES/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download"></span> Spanish</a></li>
-            <li><a href="{{ site.baseurl }}/downloads/es_ES/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download"></span> Spanish (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/ar/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Arabic"></span> عربى</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/bn_BD/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Bengali"></span> বাঙালি</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/zh_CN/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Chinese"></span> 中文</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/fr/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download French"></span> Français</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/fr/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download French"></span> Français (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download English"></span> English</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download English"></span> English (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/de/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download German"></span> Deutsche</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/it/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Italian"></span> Italiano</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/ja/github-git-cheat-sheet"><span class="octicon octicon-cloud-download Japanese"></span> 日本語</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/ja/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Japanese"></span> 日本語 (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/kr/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Korean"></span> 한국어</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/pt_BR/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Portuguese Brazil"></span> Português (Brasil)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/pt_BR/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Portuguese Brazil"></span> Português (Brasil) (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/pt_PT/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Portuguese Portugal"></span> Português (Portugal)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/pt_PT/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Portuguese Portugal"></span> Português (Portugal) (PDF)</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/sk/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Slovak"></span> Slovenský</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/es_ES/github-git-cheat-sheet/"><span class="octicon octicon-cloud-download Spanish"></span> Español</a></li>
+            <li><a href="{{ site.baseurl }}/downloads/es_ES/github-git-cheat-sheet.pdf"><span class="octicon octicon-cloud-download Spanish"></span> Español (PDF)</a></li>
           </ul>
         </div>
         <div class="cheat-sheet">


### PR DESCRIPTION
## Overview
This pull request changes the language labels on cheat sheets. Now, a French cheat sheet won't say "French", it will say "Français". This resolves https://github.com/github/training-kit/issues/544. 

### Questions & Review
- Do we want to change the order of the cheat sheets now? They were alphabetized before in English. Now, I don't know how we should do it. 
- How can we check these are correct? 

@github/services-entireteam @JasonEtco What do you think? 