### PR TITLE
CONTRIBUTING refresh for training-kit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,119 @@
-# Help Us Improve These Materials
+# Contributing to training-kit
 
-We're always looking for contributions to help improve these materials. If you have corrections, polish, or materials contributions, please submit them via a [Pull Request](https://help.github.com/articles/using-pull-requests). 
+:tada: Thank you for taking the time to contribute and for seeking out these instructions. We :heart: community contributions to these materials.
 
-If your contribution is larger than a syntax fix or sentence re-wording, please initiate a discussion via a new Issue (type `c` after switching focus to the [Issues](https://github.com/github/training-kit/issues) tab) so we can help guide your contribution to the right location in the materials.
+### Table of Contents
+
+[Code of Conduct](#code-of-conduct)
+
+[I just want to see the published resources!](https://services.github.com/on-demand/)
+
+[What should I know before I contribute?](#what-should-i-know-before-i-contribute?)
+- [The goal of these resources](#the-goal-of-these-resources)
+- [Types of contributions we love](#types-of-contributions-we-love)
+
+[How to contribute](#how-to-contribute)
+- [Report a bug](#report-a-bug)
+- [Translate existing resources](#translate-existing-resources)
+- [Contribute a new resource or course](#contribute-a-new-resource-or-course)
+- [Not sure where to start?](#not-sure-where-to-start?)
+
+[Step-by-step contribution guide](#step-by-step-contribution-guide)
+- [Our content philosophy](#our-content-philosophy)
+- [Content structure](#content-structure)
+- [Building and testing](#building-and-testing)
+
+<hr>
+
+## Code of Conduct
+
+This project and everyone who participates in it is governed by the [Contributor Covenant Code of Conduct](community.md/#Contributor-Covenant-Code-of-Conduct). By participating, you are expected to uphold this code. Please report unacceptable behavior to [services@github.com](mailto:services@github.com).
+
+<hr>
+
+## What should I know before I get started?
+
+### The goal of these resources
+
+These materials are designed to help those new to Git, GitHub and software development as a whole. By using these resources, we hope users will:
+
+- Feel welcome and become active contributors in the open source community
+- Complete hands-on activities and receive immediate support from [Teacherbot](https://github.com/teacher-bot/teacherbot), members of the community, and [GitHub's Training team](community.md/#github-trainers)
+- Learn best practices for using Git, GitHub and other GitHub supported projects such as Electron, Atom, etc
+- Learn how to use the applications within GitHub's ecosystem to build better software
+
+### Types of contributions we love
+
+We're always looking for contributions to help improve these resources. This includes:
+
+- Improving the existing classes and resources
+- Translations of existing resources such as the [cheatsheets](/downloads/) into new languages
+- Adding new classes or resources aligned with the [goals](#the-goal-of-these-resources)
+
+## How to contribute
+
+### Report a bug
+
+Oops, thanks for finding that! If you know how to fix it, please feel free to fork the repository and submit a change via Pull Request (Not sure how to do that? [We have a course for you](https://services.github.com/on-demand/)).
+
+If you aren't sure how to fix it or just don't have time, we invite you to open a [new Issue](https://github.com/github/training-kit/issues/new). Please be sure to provide information so we can recreate the error.
+
+### Translate existing resources
+
+Several community members have been kind enough to translate the [Git Cheat Sheets](https://github.com/github/training-kit/tree/master/downloads) into various languages. At this time, we are only set up to serve the cheat sheets in various languages (but maybe you can help us change that :wink:) If you are planning to contribute a translation, please do the following:
+
+- Fork this repository
+- Create a new folder in the [downloads directory](https://github.com/github/training-kit/tree/master/downloads) using the standard abbreviation for the language you are providing.
+- Copy the most recent [English version of the cheatsheet](https://github.com/github/training-kit/blob/master/downloads/github-git-cheat-sheet.md) to the folder you created.
+- Complete the translation
+- Add a link to the translated resource on [/resources/cheatsheets/index.html](https://github.com/github/training-kit/blob/master/resources/cheatsheets/index.html)
+- Open a pull request against the `master` branch of this repository.
+- Be sure to @ mention a couple of your friends who are native speakers and ask them to review the translation.
+- Update your translation based on feedback from your friends.
+
+When this process is complete, we will be happy to merge the completed document.
+
+### Contribute something new
+
+Whether you have an idea to make it better, or want to contribute a whole new course or resource ... we :heart: new ideas! We invite you to open a new [Issue](https://github.com/github/training-kit/issues/new) to talk about it before you invest too much time. Of course, if you want to experiment first, you can [fork this repository](https://help.github.com/articles/working-with-forks/) and submit your idea via a Pull Request.
+
+When you are contributing something new, we ask you to be familiar with our content philosophy, the structure of the repository, and building [Jekyll](https://jekyllrb.com/) sites locally. See the sections below for more information.
+
+### Not sure where to start?
+
+If you just want to help out, but don't have a particular change in mind, check out the [open issues](https://github.com/github/training-kit/issues) for projects you can tackle, review an [open pull request](https://github.com/github/training-kit/pulls), or check out [the project ROADMAP](https://github.com/github/training-kit/projects/1).
+
+## Step-by-step contribution guide
+
+### Our content philosophy
+
+We are eager to create materials that are easy to use and follow! To that end, here are a few guidelines we ask you to keep in mind:
+
+- We focus on providing friendly and clear, step-by-step instructions.
+- Courses should include a project repository that allows each students to complete an activity.
+- We focus on minimalism in our instructions, giving the learner the opportunity to study the concept in greater detail with the Tell Me Why feature.
+- We appeal to multiple learning styles. Some learners like to read, some like to watch videos, and others just want a recipe.
+
+### Content structure
+
+This repository contains two major collections: [on-demand training courses](https://services.github.com/on-demand/) and listings of [our favorite resources](/resources). We help users navigate these collections sequentially with the [learning path](/resources/learning-path).
+
+#### On-demand course structure
+
+Adding an on-demand course requires you to do the following:
+
+- Add a folder in the [paths directory](/paths) based on the course name
+- Add the course pages in the new folder you created. For an example of a sequential course, check out the [Introduction to GitHub course](/paths/intro-to-github) for a non-sequential course, check out [Git Out of Trouble](/paths/git-trouble)
+- Add the course to the `main` navigation in [_data/navigation.yml](_data/navigation.yml) and add your course navigation in a new section at the end of the files
+
+### Building and testing
+
+When you are ready to test your changes, you will want to build the repository locally. This is fully automated through a series of shell scripts based [the scripts to rule them all](https://github.com/github/scripts-to-rule-them-all)!
+
+To build of the materials do the following:
+
+1. Run `script/setup`
+1. Run `sass --watch assets/_scss/main.scss:assets/css/main.css` to compile the SCSS
+1. Run `script/server`
+    - When successful, the script will initiate a local server at `http://127.0.0.1:4000/on-demand`.
+1. Simply paste that into your favorite web-browser and you will be ready to test

--- a/README.md
+++ b/README.md
@@ -9,52 +9,15 @@ This repository contains the completely open source on-demand training hosted at
 
 ## We :heart: Contributors Like You!
 
-**We’re eager to work with you**, our user community to improve these materials and develop new ones. Here's how you can help:
-
-- **You spotted a mistake:** please feel free to fork the repository and submit a change via Pull Request (not sure how to do that, [we have a course for you](https://services.github.com{{site.baseurl}})).
-- **You have an idea to make it better:** we :heart: new ideas! We invite you to open a new [Issue](https://github.com/github/training-kit/issues) if you want to talk about it, or you can [fork this repository](https://help.github.com/articles/working-with-forks/) and submit your idea via a Pull Request.
-- **You just want to help:** check out the [open issues](https://github.com/github/training-kit/issues) for projects you can tackle, review an [open pull request](https://github.com/github/training-kit/pulls), or check out [the project ROADMAP](https://github.com/github/training-kit/projects/1).
-
-For more information on contributing to this repository, check out our [CONTRIBUTING guide](https://github.com/github/training-kit/blob/master/CONTRIBUTING.md).
-
-## :world_map: Finding Your Way
-
-This repository contains three primary resources:
-
-- Our current [on-demand courses](https://services.github.com{{site.baseurl}}/) can be found in the [paths directory](/paths)
-- The translations of our popular [Git Cheat Sheets](https://services.github.com{{site.baseurl}}/downloads/github-git-cheat-sheet.pdf) can be found in the [downloads directory](/downloads). We're always looking for more. _P.S._ Right now the PDF generation is a manual process so please mention @github/services-training for assistance in getting your translation moved to the PDF.
-- The recommended Training Path can be found [here](https://services.github.com/resources/learning-path/).
-
-## Our Content Philosophy
-
-We are eager to create materials that are easy to use and follow! To that end, here are a few guidelines we ask you to keep in mind:
-
-- We focus on providing clear, step-by-step instructions for completing an activity, giving the learner the opportunity to study the concept in greater detail with the Tell Me Why feature.
-- We focus on minimalism.
+**We’re eager to work with you**, our user community to improve these materials and develop new ones. Please check out our [CONTRIBUTING guide](https://github.com/github/training-kit/blob/master/CONTRIBUTING.md) for more information.
 
 ## Projects Used in Training-Kit
+
 - We use [Jekyll](https://jekyllrb.com/) and [Markdown](https://guides.github.com/features/mastering-markdown/).
 - The theme for the on-demand training is [Minimal Mistakes](https://mmistakes.github.io/minimal-mistakes/) and has some [amazing documentation](https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/).
 - The corner badge of an Octocat is from [tholman.com](http://tholman.com/github-corners/)
 
-## Building and Packaging
-
-#### Building and Testing Locally
-
-When you are ready to test your changes, you will want to build the repository locally. This is fully automated through a series of shell scripts based [the scripts to rule them all](https://github.com/github/scripts-to-rule-them-all)!
-
-To perform a build of the materials perform the following:
-
-1. Run `script/setup`
-1. Run `script/server`.
-    - When successful, the script will initiate a local server at `http://127.0.0.1:4000{{site.baseurl}}`.
-1. Simply paste that into your favorite web-browser and you will be ready to test.
-1. You'll also need to run the following script to compile the SCSS (you can remove the `watch` flag if desired):
-```
-sass --watch assets/_scss/main.scss:assets/css/main.css
-```
-
-#### Packaging for Viewing Behind Your Firewall
+## Packaging for Viewing Behind Your Firewall
 
 If you'd like to have a copy of the files to be served from a web server inside of your firewall, start by running `script/package`.
 


### PR DESCRIPTION
## TL;DR

Adding a more robust CONTRIBUTING guide per our aspirations in #415.

### Next Steps

I would like to study a few more CONTRIBUTING guides and consider additional topics to discuss here. Including:

- [atom/atom](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)
- [opengovernment](https://github.com/opengovernment/opengovernment/blob/master/CONTRIBUTING.md)
- [codebuddies](https://github.com/codebuddiesdotorg/codebuddies/blob/master/contributing.md) - per @hollenberry comment in #440 
- [hoodie](https://github.com/hoodiehq/hoodie/blob/master/CONTRIBUTING.md) - per @hollenberry comment in #440
- In the CONTRIBUTING guide, explain your label system and include search links - [for example](https://github.com/github/training-kit/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)

I also want to compare it to these templates/checklists for additional inspiration:

- [ ] [opensource.guide](https://opensource.guide/starting-a-project/#writing-your-contributing-guidelines)
- [ ] @nayafia's [CONTRIBUTING-template](https://github.com/nayafia/contributing-template/blob/master/CONTRIBUTING-template.md)
- [ ] mozilla's guide for [How to Build a CONTRIBUTING.md](http://mozillascience.github.io/working-open-workshop/contributing/)

@github/services-training I welcome your :eyes:, ✏️ , and 💡 on what we want to add here. 
