### PR TITLE
Correct {{site.baseurl}} to "on-demand" fixing broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 # GitHub Training Kit
 ### Home of GitHub's On-Demand training
 
-This repository contains the completely open source on-demand training hosted at https://services.github.com{{site.baseurl}}/. These materials are provided under a [_Creative Commons License_ license](https://github.com/github/training-kit/blob/master/LICENSE).
+This repository contains the completely open source on-demand training hosted at https://services.github.com/on-demand/. These materials are provided under a [_Creative Commons License_ license](https://github.com/github/training-kit/blob/master/LICENSE).
 
 ## We :heart: Contributors Like You!
 
 **We’re eager to work with you**, our user community to improve these materials and develop new ones. Here's how you can help:
 
-- **You spotted a mistake:** please feel free to fork the repository and submit a change via Pull Request (not sure how to do that, [we have a course for you](https://services.github.com{{site.baseurl}})).
+- **You spotted a mistake:** please feel free to fork the repository and submit a change via Pull Request (not sure how to do that, [we have a course for you](https://services.github.com/on-demand/)).
 - **You have an idea to make it better:** we :heart: new ideas! We invite you to open a new [Issue](https://github.com/github/training-kit/issues) if you want to talk about it, or you can [fork this repository](https://help.github.com/articles/working-with-forks/) and submit your idea via a Pull Request.
 - **You just want to help:** check out the [open issues](https://github.com/github/training-kit/issues) for projects you can tackle, review an [open pull request](https://github.com/github/training-kit/pulls), or check out [the project ROADMAP](https://github.com/github/training-kit/projects/1).
 
@@ -21,8 +21,8 @@ For more information on contributing to this repository, check out our [CONTRIBU
 
 This repository contains three primary resources:
 
-- Our current [on-demand courses](https://services.github.com{{site.baseurl}}/) can be found in the [paths directory](/paths)
-- The translations of our popular [Git Cheat Sheets](https://services.github.com{{site.baseurl}}/downloads/github-git-cheat-sheet.pdf) can be found in the [downloads directory](/downloads). We're always looking for more. _P.S._ Right now the PDF generation is a manual process so please mention @github/services-training for assistance in getting your translation moved to the PDF.
+- Our current [on-demand courses](https://services.github.com/on-demand/) can be found in the [paths directory](/paths)
+- The translations of our popular [Git Cheat Sheets](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf) can be found in the [downloads directory](/downloads). We're always looking for more. _P.S._ Right now the PDF generation is a manual process so please mention @github/services-training for assistance in getting your translation moved to the PDF.
 - The recommended Training Path can be found [here](https://services.github.com/resources/learning-path/).
 
 ## Our Content Philosophy
@@ -47,7 +47,7 @@ To perform a build of the materials perform the following:
 
 1. Run `script/setup`
 1. Run `script/server`.
-    - When successful, the script will initiate a local server at `http://127.0.0.1:4000{{site.baseurl}}`.
+    - When successful, the script will initiate a local server at `http://127.0.0.1:4000/`.
 1. Simply paste that into your favorite web-browser and you will be ready to test.
 1. You'll also need to run the following script to compile the SCSS (you can remove the `watch` flag if desired):
 ```
@@ -69,7 +69,7 @@ If you'd like to have a copy of the files to be served from a web server inside 
 Site content is licensed under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/). CC-BY-4.0 gives you permission to use content for almost any purpose but does not grant you any trademark permissions, so long as you note the license and give credit, such as follows:
 
 > Content based on
-> <a href="https://services.github.com{{site.baseurl}}/">services.github.com{{site.baseurl}}</a>
+> <a href="https://services.github.com/on-demand/">services.github.com/on-demand/</a>
 > used under the
 > <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>
 > license.</a>


### PR DESCRIPTION
Not sure if I am missing something here, but the href links in the README file are broken. Fixed them in this PR.
