### PR TITLE
Add default page language

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,3 +85,10 @@ sass:
 
 # Custom site configuration
 lang: en
+
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      lang: "en"


### PR DESCRIPTION
When I merged in #593, I inadvertently broke pages that had no translation. This PR fixes that.

Before:

<img width="1051" alt="screen shot 2017-09-21 at 7 03 56 pm" src="https://user-images.githubusercontent.com/16547949/30722512-a3d0bbb6-9eff-11e7-97c6-49cb3d679bbe.png">

After:

<img width="1048" alt="screen shot 2017-09-21 at 7 04 44 pm" src="https://user-images.githubusercontent.com/16547949/30722541-bfde2528-9eff-11e7-9991-d8fb2a48b642.png">

I should probably get at least 2 other 👍 from anyone at @github/services-training to make sure I'm not breaking anything else!