### PR TITLE
Remove merge-conflict course from timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,7 @@ courses:
     description: Learn how to **use the Command Line** to copy a repository to your computer, track changes and communicate with GitHub.
     image: images/about/collabocats.jpg
     imageAlt: The 'collabocats', cartoon of octocats pictured on two laptops with symbols showing they're collaborating on code
-    link: /github-cli
-  - title: Managing Merge Conflicts
-    description: First you had issues, now you have conflicts. Learn how to resolve at least one of them.
-    image: ./images/skatetocat.png
-    imageAlt: The 'skatetocat', a cartoon of an octocat using a skateboard and having fun
-    link: /merge-conflicts    
+    link: /github-cli    
   - title: GitHub for Windows Users
     description: Learn how to configure your local git environment to work with GitHub and how to complete GitHub flow using the GitHub Extension for Visual Studio.
     image: images/red-polo.png


### PR DESCRIPTION
The merge conflict course has an immediate need for some content fixes, so removing it from the timeline so they can be addressed. 

Super zoomed out image. MC course no longer listed
![image](https://user-images.githubusercontent.com/18329853/30966123-cc05eca2-a425-11e7-95e9-998951f4b10f.png)
