### PR TITLE
Point help to class repos directly

### DIFF
--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -34,6 +34,7 @@ en: &DEFAULT_EN
   show-me-how           : "Show me how"
   troubleshooting       : "Help me troubleshoot"
   tell-me-why           : "Tell me why"
+  get-help              : "Get Help"
   stuck                 : "Stuck? Open an issue in the repository for this class and mention <strong>@githubteacher</strong> for help from one of the GitHub trainers!"
   continue              : "Continue"
 en-US:
@@ -75,6 +76,7 @@ es: &DEFAULT_ES
   show-me-how           : "Enséñame cómo"
   troubleshooting       : "Ayúdame a resolver"
   tell-me-why           : "Dime por qué"
+  get-help              : "Pide Ayuda"
   stuck                 : "¿Atascado? Abre un tema (issue) en el repositorio para esta clase y menciona a <strong>@githubteacher</strong> para obtener ayuda de uno de los instructores de GitHub."
   continue              : "Continuar"
 es-ES:

--- a/_layouts/simple-class.html
+++ b/_layouts/simple-class.html
@@ -121,7 +121,8 @@ layout: default
           {% endif %}
 
           <div class="flash mb-2 flash-success">
-            {{ site.data.ui-text[page.lang].stuck }}
+            <div class="float-left p-1 mr-3"><a href="{{ page.help }}" class="btn btn-primary">{{ site.data.ui-text[page.lang].get-help }}</a></div>
+            <div class="overflow-hidden">{{ site.data.ui-text[page.lang].stuck }}</div>
           </div>
 
           {% if page.next-page %}

--- a/_layouts/simple-class.html
+++ b/_layouts/simple-class.html
@@ -120,10 +120,12 @@ layout: default
             </details>
           {% endif %}
 
+          {% if page.help %}
           <div class="flash mb-2 flash-success">
             <div class="float-left p-1 mr-3"><a href="{{ page.help }}" class="btn btn-primary">{{ site.data.ui-text[page.lang].get-help }}</a></div>
             <div class="overflow-hidden">{{ site.data.ui-text[page.lang].stuck }}</div>
           </div>
+          {% endif %}
 
           {% if page.next-page %}
             <a href="{{ site.baseurl }}{{ page.next-page }}" class="btn">{{ site.data.ui-text[page.lang].continue }}</a>

--- a/paths/electron/distributing/01-share-apps.md
+++ b/paths/electron/distributing/01-share-apps.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/distributing/01-share-apps.md
+++ b/paths/electron/distributing/01-share-apps.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/distributing/02-native-app-discovery.md
+++ b/paths/electron/distributing/02-native-app-discovery.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/distributing/02-native-app-discovery.md
+++ b/paths/electron/distributing/02-native-app-discovery.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/distributing/03-sharing-on-websites.md
+++ b/paths/electron/distributing/03-sharing-on-websites.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/distributing/04-celebrate.md
+++ b/paths/electron/distributing/04-celebrate.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/distributing/04-celebrate.md
+++ b/paths/electron/distributing/04-celebrate.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/01-packaging-electron.md
+++ b/paths/electron/packaging-apps/01-packaging-electron.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/01-packaging-electron.md
+++ b/paths/electron/packaging-apps/01-packaging-electron.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/02-using-electron-packager.md
+++ b/paths/electron/packaging-apps/02-using-electron-packager.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/02-using-electron-packager.md
+++ b/paths/electron/packaging-apps/02-using-electron-packager.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/03-adding-an-icon.md
+++ b/paths/electron/packaging-apps/03-adding-an-icon.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/03-adding-an-icon.md
+++ b/paths/electron/packaging-apps/03-adding-an-icon.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/04-testing.md
+++ b/paths/electron/packaging-apps/04-testing.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/04-testing.md
+++ b/paths/electron/packaging-apps/04-testing.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/05-celebrate.md
+++ b/paths/electron/packaging-apps/05-celebrate.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/packaging-apps/05-celebrate.md
+++ b/paths/electron/packaging-apps/05-celebrate.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/01-getting-started.md
+++ b/paths/electron/starting-with-electron/01-getting-started.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/01-getting-started.md
+++ b/paths/electron/starting-with-electron/01-getting-started.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/02-electron-boilerplate.md
+++ b/paths/electron/starting-with-electron/02-electron-boilerplate.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/02-electron-boilerplate.md
+++ b/paths/electron/starting-with-electron/02-electron-boilerplate.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/03-git-repository.md
+++ b/paths/electron/starting-with-electron/03-git-repository.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/03-git-repository.md
+++ b/paths/electron/starting-with-electron/03-git-repository.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/04-creating-app-files.md
+++ b/paths/electron/starting-with-electron/04-creating-app-files.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/04-creating-app-files.md
+++ b/paths/electron/starting-with-electron/04-creating-app-files.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/05-running-the-app.md
+++ b/paths/electron/starting-with-electron/05-running-the-app.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/05-running-the-app.md
+++ b/paths/electron/starting-with-electron/05-running-the-app.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/06-add-to-index.md
+++ b/paths/electron/starting-with-electron/06-add-to-index.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/06-add-to-index.md
+++ b/paths/electron/starting-with-electron/06-add-to-index.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/07-add-to-css.md
+++ b/paths/electron/starting-with-electron/07-add-to-css.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/07-add-to-css.md
+++ b/paths/electron/starting-with-electron/07-add-to-css.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/08-add-to-js.md
+++ b/paths/electron/starting-with-electron/08-add-to-js.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/08-add-to-js.md
+++ b/paths/electron/starting-with-electron/08-add-to-js.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/09-celebrate.md
+++ b/paths/electron/starting-with-electron/09-celebrate.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/electron/starting-with-electron/09-celebrate.md
+++ b/paths/electron/starting-with-electron/09-celebrate.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-electron-app/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/01-github-CLI-introduction.md
+++ b/paths/github-cli/01-github-CLI-introduction.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/01-github-CLI-introduction.md
+++ b/paths/github-cli/01-github-CLI-introduction.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/02-local-configurations.md
+++ b/paths/github-cli/02-local-configurations.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/02-local-configurations.md
+++ b/paths/github-cli/02-local-configurations.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/03-create-repo-in-browser.md
+++ b/paths/github-cli/03-create-repo-in-browser.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/03-create-repo-in-browser.md
+++ b/paths/github-cli/03-create-repo-in-browser.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/04-choose-a-theme.md
+++ b/paths/github-cli/04-choose-a-theme.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/04-choose-a-theme.md
+++ b/paths/github-cli/04-choose-a-theme.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/05-cloning.md
+++ b/paths/github-cli/05-cloning.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/05-cloning.md
+++ b/paths/github-cli/05-cloning.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/06-create-branch.md
+++ b/paths/github-cli/06-create-branch.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/06-create-branch.md
+++ b/paths/github-cli/06-create-branch.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/07-local-files.md
+++ b/paths/github-cli/07-local-files.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/07-local-files.md
+++ b/paths/github-cli/07-local-files.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/08-2-step-commit.md
+++ b/paths/github-cli/08-2-step-commit.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 eader:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/08-2-step-commit.md
+++ b/paths/github-cli/08-2-step-commit.md
@@ -1,6 +1,7 @@
 ---
 layout: simple-class
-header:
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+eader:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)
 title: Add Local Commits With Git

--- a/paths/github-cli/09-push-and-pull.md
+++ b/paths/github-cli/09-push-and-pull.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/09-push-and-pull.md
+++ b/paths/github-cli/09-push-and-pull.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/10-merging.md
+++ b/paths/github-cli/10-merging.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/10-merging.md
+++ b/paths/github-cli/10-merging.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/11-view-your-site.md
+++ b/paths/github-cli/11-view-your-site.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/11-view-your-site.md
+++ b/paths/github-cli/11-view-your-site.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/12-sync-local-repo.md
+++ b/paths/github-cli/12-sync-local-repo.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/12-sync-local-repo.md
+++ b/paths/github-cli/12-sync-local-repo.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/13-join-class-repo.md
+++ b/paths/github-cli/13-join-class-repo.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/13-join-class-repo.md
+++ b/paths/github-cli/13-join-class-repo.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/14-review-local-workflow.md
+++ b/paths/github-cli/14-review-local-workflow.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/14-review-local-workflow.md
+++ b/paths/github-cli/14-review-local-workflow.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/15-push-and-open-pr.md
+++ b/paths/github-cli/15-push-and-open-pr.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/15-push-and-open-pr.md
+++ b/paths/github-cli/15-push-and-open-pr.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/16-collaborate.md
+++ b/paths/github-cli/16-collaborate.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/16-collaborate.md
+++ b/paths/github-cli/16-collaborate.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/17-merge-changes.md
+++ b/paths/github-cli/17-merge-changes.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/17-merge-changes.md
+++ b/paths/github-cli/17-merge-changes.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/viewing-history.md
+++ b/paths/github-cli/viewing-history.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-cli/viewing-history.md
+++ b/paths/github-cli/viewing-history.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/01-class-introduction.md
+++ b/paths/github-desktop/01-class-introduction.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/01-class-introduction.md
+++ b/paths/github-desktop/01-class-introduction.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/02-install-desktop.md
+++ b/paths/github-desktop/02-install-desktop.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/02-install-desktop.md
+++ b/paths/github-desktop/02-install-desktop.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/03-creating-repository-in-browser.md
+++ b/paths/github-desktop/03-creating-repository-in-browser.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/03-creating-repository-in-browser.md
+++ b/paths/github-desktop/03-creating-repository-in-browser.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/04-choose-a-theme.md
+++ b/paths/github-desktop/04-choose-a-theme.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/04-choose-a-theme.md
+++ b/paths/github-desktop/04-choose-a-theme.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/05-cloning-repository-locally.md
+++ b/paths/github-desktop/05-cloning-repository-locally.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/05-cloning-repository-locally.md
+++ b/paths/github-desktop/05-cloning-repository-locally.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/06-create-a-branch.md
+++ b/paths/github-desktop/06-create-a-branch.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/06-create-a-branch.md
+++ b/paths/github-desktop/06-create-a-branch.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/07-make-local-changes.md
+++ b/paths/github-desktop/07-make-local-changes.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/07-make-local-changes.md
+++ b/paths/github-desktop/07-make-local-changes.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/08-add-commits-desktop.md
+++ b/paths/github-desktop/08-add-commits-desktop.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/08-add-commits-desktop.md
+++ b/paths/github-desktop/08-add-commits-desktop.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/09-open-pull-request.md
+++ b/paths/github-desktop/09-open-pull-request.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/09-open-pull-request.md
+++ b/paths/github-desktop/09-open-pull-request.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/10-merging-pull-requests.md
+++ b/paths/github-desktop/10-merging-pull-requests.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/10-merging-pull-requests.md
+++ b/paths/github-desktop/10-merging-pull-requests.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/11-view-your-site.md
+++ b/paths/github-desktop/11-view-your-site.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/11-view-your-site.md
+++ b/paths/github-desktop/11-view-your-site.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/12-sync-local-repo.md
+++ b/paths/github-desktop/12-sync-local-repo.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/12-sync-local-repo.md
+++ b/paths/github-desktop/12-sync-local-repo.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/13-add-site-to-showcase.md
+++ b/paths/github-desktop/13-add-site-to-showcase.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/13-add-site-to-showcase.md
+++ b/paths/github-desktop/13-add-site-to-showcase.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/14-review-local-workflow.md
+++ b/paths/github-desktop/14-review-local-workflow.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/14-review-local-workflow.md
+++ b/paths/github-desktop/14-review-local-workflow.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/15-push-and-open-pr.md
+++ b/paths/github-desktop/15-push-and-open-pr.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/15-push-and-open-pr.md
+++ b/paths/github-desktop/15-push-and-open-pr.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/16-collaborate.md
+++ b/paths/github-desktop/16-collaborate.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/16-collaborate.md
+++ b/paths/github-desktop/16-collaborate.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/17-merge.md
+++ b/paths/github-desktop/17-merge.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/github-desktop/17-merge.md
+++ b/paths/github-desktop/17-merge.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/on-demand-github-pages/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/01-introduction.md
+++ b/paths/graphql/01-introduction.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/01-introduction.md
+++ b/paths/graphql/01-introduction.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/02-first-use.md
+++ b/paths/graphql/02-first-use.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/02-first-use.md
+++ b/paths/graphql/02-first-use.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/03-first-query.md
+++ b/paths/graphql/03-first-query.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/03-first-query.md
+++ b/paths/graphql/03-first-query.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/04-query-info.md
+++ b/paths/graphql/04-query-info.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/04-query-info.md
+++ b/paths/graphql/04-query-info.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/05-another-query.md
+++ b/paths/graphql/05-another-query.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/05-another-query.md
+++ b/paths/graphql/05-another-query.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/06-mutation.md
+++ b/paths/graphql/06-mutation.md
@@ -1,6 +1,6 @@
 ---
 layout: simple-class
-help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/graphql/06-mutation.md
+++ b/paths/graphql/06-mutation.md
@@ -1,5 +1,6 @@
 ---
 layout: simple-class
+help: https://github.com/githubschool/graph-ql/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/00-bienvenida.md
+++ b/paths/intro-to-github-es/00-bienvenida.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-00
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/00-bienvenida.md
+++ b/paths/intro-to-github-es/00-bienvenida.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-00
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/01-crear-cuenta-github.md
+++ b/paths/intro-to-github-es/01-crear-cuenta-github.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-01
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/01-crear-cuenta-github.md
+++ b/paths/intro-to-github-es/01-crear-cuenta-github.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-01
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/02-unete-repo-clase.md
+++ b/paths/intro-to-github-es/02-unete-repo-clase.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-02
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/02-unete-repo-clase.md
+++ b/paths/intro-to-github-es/02-unete-repo-clase.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-02
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/03-explora-repositorio.md
+++ b/paths/intro-to-github-es/03-explora-repositorio.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-03
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/03-explora-repositorio.md
+++ b/paths/intro-to-github-es/03-explora-repositorio.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-03
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/04-flujo-github.md
+++ b/paths/intro-to-github-es/04-flujo-github.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-04
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/04-flujo-github.md
+++ b/paths/intro-to-github-es/04-flujo-github.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-04
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/05-creando-rama-branch.md
+++ b/paths/intro-to-github-es/05-creando-rama-branch.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-05
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/05-creando-rama-branch.md
+++ b/paths/intro-to-github-es/05-creando-rama-branch.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-05
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/06-buscar-coordenadas.md
+++ b/paths/intro-to-github-es/06-buscar-coordenadas.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-06
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/06-buscar-coordenadas.md
+++ b/paths/intro-to-github-es/06-buscar-coordenadas.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-06
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/07-trabajar-en-github.md
+++ b/paths/intro-to-github-es/07-trabajar-en-github.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-07
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/07-trabajar-en-github.md
+++ b/paths/intro-to-github-es/07-trabajar-en-github.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-07
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/08-crear-pull-request.md
+++ b/paths/intro-to-github-es/08-crear-pull-request.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-08
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/08-crear-pull-request.md
+++ b/paths/intro-to-github-es/08-crear-pull-request.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-08
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/09-colaborar-en-github.md
+++ b/paths/intro-to-github-es/09-colaborar-en-github.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-09
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/09-colaborar-en-github.md
+++ b/paths/intro-to-github-es/09-colaborar-en-github.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-09
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/10-editar-en-github.md
+++ b/paths/intro-to-github-es/10-editar-en-github.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-10
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/10-editar-en-github.md
+++ b/paths/intro-to-github-es/10-editar-en-github.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-10
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/11-merge-pull-requests.md
+++ b/paths/intro-to-github-es/11-merge-pull-requests.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-11
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/11-merge-pull-requests.md
+++ b/paths/intro-to-github-es/11-merge-pull-requests.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-11
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/12-celebrar.md
+++ b/paths/intro-to-github-es/12-celebrar.md
@@ -2,7 +2,7 @@
 lang: es
 ref: intro-to-github-12
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github-es/12-celebrar.md
+++ b/paths/intro-to-github-es/12-celebrar.md
@@ -2,6 +2,7 @@
 lang: es
 ref: intro-to-github-12
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/00-welcome.md
+++ b/paths/intro-to-github/00-welcome.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-00
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/00-welcome.md
+++ b/paths/intro-to-github/00-welcome.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-00
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/01-create-github-account.md
+++ b/paths/intro-to-github/01-create-github-account.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-01
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/01-create-github-account.md
+++ b/paths/intro-to-github/01-create-github-account.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-01
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/02-join-class-repo.md
+++ b/paths/intro-to-github/02-join-class-repo.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-02
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/02-join-class-repo.md
+++ b/paths/intro-to-github/02-join-class-repo.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-02
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/03-exploring-repository.md
+++ b/paths/intro-to-github/03-exploring-repository.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-03
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/03-exploring-repository.md
+++ b/paths/intro-to-github/03-exploring-repository.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-03
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/04-github-flow.md
+++ b/paths/intro-to-github/04-github-flow.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-04
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/04-github-flow.md
+++ b/paths/intro-to-github/04-github-flow.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-04
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/05-creating-a-branch.md
+++ b/paths/intro-to-github/05-creating-a-branch.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-05
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/05-creating-a-branch.md
+++ b/paths/intro-to-github/05-creating-a-branch.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-05
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/06-find-coordinates.md
+++ b/paths/intro-to-github/06-find-coordinates.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-06
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/06-find-coordinates.md
+++ b/paths/intro-to-github/06-find-coordinates.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-06
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/07-working-on-github.md
+++ b/paths/intro-to-github/07-working-on-github.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-07
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/07-working-on-github.md
+++ b/paths/intro-to-github/07-working-on-github.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-07
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/08-create-pull-request.md
+++ b/paths/intro-to-github/08-create-pull-request.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-08
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/08-create-pull-request.md
+++ b/paths/intro-to-github/08-create-pull-request.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-08
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/09-collaborate-pull-request.md
+++ b/paths/intro-to-github/09-collaborate-pull-request.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-09
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/09-collaborate-pull-request.md
+++ b/paths/intro-to-github/09-collaborate-pull-request.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-09
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/10-edit-on-github.md
+++ b/paths/intro-to-github/10-edit-on-github.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-10
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/10-edit-on-github.md
+++ b/paths/intro-to-github/10-edit-on-github.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-10
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/11-merging-pull-requests.md
+++ b/paths/intro-to-github/11-merging-pull-requests.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-11
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/11-merging-pull-requests.md
+++ b/paths/intro-to-github/11-merging-pull-requests.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-11
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/12-celebrate.md
+++ b/paths/intro-to-github/12-celebrate.md
@@ -2,7 +2,7 @@
 lang: en
 ref: intro-to-github-12
 layout: simple-class
-help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.&labels=Help%20Wanted
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)

--- a/paths/intro-to-github/12-celebrate.md
+++ b/paths/intro-to-github/12-celebrate.md
@@ -2,6 +2,7 @@
 lang: en
 ref: intro-to-github-12
 layout: simple-class
+help: https://github.com/githubschool/open-enrollment-classes-introduction-to-github/issues/new?title=I%20need%20help&body=Describe%20what%20you%20need%20help%20with%20here.
 header:
   overlay_image: cover.jpeg
   overlay_filter: rgba(46, 129, 200, 0.6)


### PR DESCRIPTION
The bottom of each page currently says to "ask for help in the class repo", but it doesn't actually link the learner to that page. So unless the user has the class repo on another window, it might be difficult for them to figure out exactly where to get help. Additionally, new users may not be familiar with concepts like "open a new issue".

This PR tries to make asking for help easy by pointing each page to a specific link where learners can ask for help. That link is currently just a new issue with some pre populated text. In the future, these templates can be improved so that we can get information about exactly which page the learner is stuck at.

Before | After
--- | ---
![screen shot 2017-09-28 at 11 36 18 pm](https://user-images.githubusercontent.com/16547949/30999927-1b1e5204-a4a6-11e7-9c53-d7de4b048f9c.png) | ![screen shot 2017-09-28 at 11 36 23 pm](https://user-images.githubusercontent.com/16547949/30999933-22f63dd4-a4a6-11e7-84a3-ead0647ec527.png)