### PR TITLE
Translate site and learning path title to Spanish

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -20,7 +20,7 @@ main:
   es:
     - title: Resources
       url: /resources/
-    - title: Learning Path
+    - title: Ruta de aprendizaje
       url: /resources/learning-path/es/
     - title: Upcoming Events
       abs: https://services.github.com/#upcoming-events

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,7 +3,7 @@ banner:
     title: On Demand Training
     url: /
   es:
-    title: On Demand Training
+    title: Aprende a tu ritmo
     url: /es/
 
 main:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -20,7 +20,7 @@ main:
   es:
     - title: Resources
       url: /resources/
-    - title: Ruta de aprendizaje
+    - title: Itinerario de aprendizaje
       url: /resources/learning-path/es/
     - title: Upcoming Events
       abs: https://services.github.com/#upcoming-events

--- a/index_es.html
+++ b/index_es.html
@@ -3,7 +3,7 @@ ref: index
 lang: es
 layout: timeline
 permalink: /es/
-title: On Demand Training
+title: Aprende a tu ritmo
 excerpt: "Tú tienes el control. Estamos contigo a lo largo del camino."
 timeline:
   showWelcome: true

--- a/resources/learning-path/index_es.html
+++ b/resources/learning-path/index_es.html
@@ -3,7 +3,7 @@ ref: learning-path
 lang: es
 layout: default
 subpage: learning-path
-title: Ruta de aprendizaje
+title: Itinerario de aprendizaje
 description: Aprender Git y GitHub puede parecer abrumador, pero con esta práctica lista de recursos educativos, te convertirás en un experto en Git en nada de tiempo.
 breadcrumbColor: "bg-gray-light"
 breadcrumbSize: "lg"

--- a/resources/learning-path/index_es.html
+++ b/resources/learning-path/index_es.html
@@ -3,7 +3,7 @@ ref: learning-path
 lang: es
 layout: default
 subpage: learning-path
-title: Learning Path
+title: Ruta de aprendizaje
 description: Aprender Git y GitHub puede parecer abrumador, pero con esta práctica lista de recursos educativos, te convertirás en un experto en Git en nada de tiempo.
 breadcrumbColor: "bg-gray-light"
 breadcrumbSize: "lg"


### PR DESCRIPTION
This PR translates the site title (_On Demand Training_ ➡️ _Aprende a tu ritmo_) and the title of _Learning Path_ ➡️ _Ruta de aprendizaje_. It closes #583.

I can 🚢 with one 👀 from @dpmex4527, @mberasategi, or any other Spanish speakers (maybe @bescalante?) willing to take a quick peek that can help rate my translation.