### PR TITLE
Restore yaml indentation

### DIFF
--- a/paths/git-trouble/fc-scenarios.md
+++ b/paths/git-trouble/fc-scenarios.md
@@ -14,7 +14,7 @@ main-content: |
 
   ## [Too Many (small) Git Commits!](../git-trouble/too-many-commits)
 
-While you were making changes, you might have created a bunch of tiny commits, but when it is time to push your changes back to your `remote`, you want to prevent your commit history from being inundated with the 30 commits you just made. This scenario guides you through creating a more concise history.
+  While you were making changes, you might have created a bunch of tiny commits, but when it is time to push your changes back to your `remote`, you want to prevent your commit history from being inundated with the 30 commits you just made. This scenario guides you through creating a more concise history.
 
   ## [Git Commit Message Sucks](../git-trouble/git-commit-message)
 

--- a/paths/git-trouble/fc-welcome.md
+++ b/paths/git-trouble/fc-welcome.md
@@ -10,7 +10,7 @@ toc: true
 sidebar:
   nav: "advanced"
 main-content: |  
-It isn’t uncommon to make a mistake while working with Git, but don’t fret, everyone does it. Getting out of a mess can be just as easy as getting into one, and this course is here to help. It outlines the different commands you can use to get out of almost **any** sticky situation helping you to save your project and prevent embarrassment.
+  It isn’t uncommon to make a mistake while working with Git, but don’t fret, everyone does it. Getting out of a mess can be just as easy as getting into one, and this course is here to help. It outlines the different commands you can use to get out of almost **any** sticky situation helping you to save your project and prevent embarrassment.
 
   ### Thanks!
   Before we begin, the GitHub Training team would like to thank the following community contributors for their work in creating meaningful content that inspired this course:


### PR DESCRIPTION
@github/services-training these errors were accidentally introduced in #612 - just a quick fix to correct indentation and make yaml happy.