### PR TITLE
Don't try to fetch map data unless #map is present

### DIFF
--- a/assets/js/mapsAPI.js
+++ b/assets/js/mapsAPI.js
@@ -1,72 +1,72 @@
----
----
 function initialize() {
-  $.getJSON(
-    'https://githubschool.github.io/open-enrollment-classes-introduction-to-github/createMap.topojson',
-    function (data) {
-      var mapSize = new google.maps.Size(256, 256), // original size, fallback for space invador images
-        scaledSize = new google.maps.Size(20, 20),  // size on map, fallback for space invador images
-        anchor = new google.maps.Point(0, 32),      // start point
-        map = new google.maps.Map(document.getElementById('map'), {
-          zoom: 2,
-          minZoom: 2,
-          center: new google.maps.LatLng(10, 15),
-          mapTypeId: 'terrain',
-          //disableDefaultUI: true,
-          mapTypeControl: false,
-          panControl: false,
-          //scaleControl: false,
-          scrollwheel: false,
-          streetViewControl: false,
-          //zoomControl: false,
-          //draggable: false,
-          styles: [
-            {
-              featureType: 'administrative',
-              elementType: 'geometry',
-              stylers: [{visibility: 'off'}]
-            },
-            {
-              featureType: 'administrative.country',
-              stylers: [{visibility: 'off'}]
-            },
-            {
-              featureType: 'water',
-              elementType: 'labels',
-              stylers: [{visibility: 'off'}]
-            },
-            {
-              featureType: 'administrative',
-              elementType: 'labels',
-              stylers: [{visibility: 'off'}]
-            }
-          ]
-        }),
-        markers = data.features.map(function (coords) {
-          var coordinates = coords.geometry.coordinates,
-            username = coords.properties.username;
+  if ($("#map").length) {
+    $.getJSON(
+      'https://githubschool.github.io/open-enrollment-classes-introduction-to-github/createMap.topojson',
+      function (data) {
+        var mapSize = new google.maps.Size(256, 256), // original size, fallback for space invador images
+            scaledSize = new google.maps.Size(20, 20),  // size on map, fallback for space invador images
+            anchor = new google.maps.Point(0, 32),      // start point
+            map = new google.maps.Map(document.getElementById('map'), {
+              zoom: 2,
+              minZoom: 2,
+              center: new google.maps.LatLng(10, 15),
+              mapTypeId: 'terrain',
+              //disableDefaultUI: true,
+              mapTypeControl: false,
+              panControl: false,
+              //scaleControl: false,
+              scrollwheel: false,
+              streetViewControl: false,
+              //zoomControl: false,
+              //draggable: false,
+              styles: [
+                {
+                  featureType: 'administrative',
+                  elementType: 'geometry',
+                  stylers: [{visibility: 'off'}]
+                },
+                {
+                  featureType: 'administrative.country',
+                  stylers: [{visibility: 'off'}]
+                },
+                {
+                  featureType: 'water',
+                  elementType: 'labels',
+                  stylers: [{visibility: 'off'}]
+                },
+                {
+                  featureType: 'administrative',
+                  elementType: 'labels',
+                  stylers: [{visibility: 'off'}]
+                }
+              ]
+            }),
+            markers = data.features.map(function (coords) {
+              var coordinates = coords.geometry.coordinates,
+                  username = coords.properties.username;
 
-          return new google.maps.Marker({
-            position: new google.maps.LatLng(
-              coordinates[1],
-              coordinates[0]
-            ),
-            map: map,
-            title: username,
-            icon: {
-              url: 'https://github.com/' + username + '.png?size=20',
-              size: mapSize,
-              scaledSize: scaledSize,
-              anchor: anchor
-            }
-          });
+              return new google.maps.Marker({
+                position: new google.maps.LatLng(
+                  coordinates[1],
+                  coordinates[0]
+                ),
+                map: map,
+                title: username,
+                icon: {
+                  url: 'https://github.com/' + username + '.png?size=20',
+                  size: mapSize,
+                  scaledSize: scaledSize,
+                  anchor: anchor
+                }
+              });
+            });
+
+        new MarkerClusterer(map, markers, {
+          imagePath: '{{site.baseurl}}/images/cluster/m',
+          averageCenter: true,
+          minimumClusterSize: 42
         });
-
-      new MarkerClusterer(map, markers, {
-        imagePath: '{{site.baseurl}}/images/cluster/m',
-        averageCenter: true,
-        minimumClusterSize: 42
-      });
-    }
-  );
+      }
+    );
+  }
 }


### PR DESCRIPTION
Closes issue #627, which raised the issue of a console error that's triggered by this file's attempt to fetch google maps data on pages without the requisite `#map` element. This is a simple fix that checks to see whether `#map` is present before proceeding with the `.getJSON` AJAX function. Only the `/intro-to-github/` page contains the map, so the console error appears on every other page.
