### PR TITLE
Change GA property to github.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ comments:
 analytics:
   provider               : google # false (default), "google", "google-universal", "custom"
   google:
-    tracking_id          : UA-80557370-2
+    tracking_id          : UA-3769691-2
 
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 


### PR DESCRIPTION
This PR changes the Google Analytics tracking ID for the Training Kit so that it matches that of all GitHub web properties. This will allow the Marketing team to [track users' journey across all of its subdomains](https://github.com/github/site-2018/issues/21).

The underlying intention of updating it in _this_ repository is so that it will use the unified ID when it's built within the larger `services-site` repository.

Closes https://github.com/github/services-site/issues/132#issuecomment-388877622