### PR TITLE
Fix columns issues on Migration Cheat Sheet page

### DIFF
--- a/_layouts/cheat-sheet.html
+++ b/_layouts/cheat-sheet.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<div class="container-lg">
+<div class="container-lg p-responsive">
   <div class="markdown-body">
     {{ content }}
   </div>

--- a/_layouts/cheat-sheet.html
+++ b/_layouts/cheat-sheet.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="container-lg p-responsive">
-  <div class="markdown-body">
+  <div class="markdown-body d-flex flex-wrap gutter">
     {{ content }}
   </div>
 </div>

--- a/downloads/subversion-migration.md
+++ b/downloads/subversion-migration.md
@@ -36,7 +36,8 @@ Learn more about SVN2Git at the project’s official home page:
 [https://github.com/nirvdrum/svn2git](https://github.com/nirvdrum/svn2git)
 {% endcapture %}
 
-<div class="col-md-6">
+<div class="d-flex flex-wrap gutter">
+<div class="col-md-6 col-12">
 {{ migration | markdownify }}
 </div>
 
@@ -80,8 +81,9 @@ git svn rebase
 Keep in mind this action rewrites your local Git history and your commit identifiers will be different.
 {% endcapture %}
 
-<div class="col-md-6">
+<div class="col-md-6 col-12">
 {{ bridging | markdownify }}
+</div>
 </div>
 
 

--- a/downloads/subversion-migration.md
+++ b/downloads/subversion-migration.md
@@ -36,7 +36,6 @@ Learn more about SVN2Git at the project’s official home page:
 [https://github.com/nirvdrum/svn2git](https://github.com/nirvdrum/svn2git)
 {% endcapture %}
 
-<div class="d-flex flex-wrap gutter">
 <div class="col-md-6 col-12">
 {{ migration | markdownify }}
 </div>
@@ -83,7 +82,6 @@ Keep in mind this action rewrites your local Git history and your commit identif
 
 <div class="col-md-6 col-12">
 {{ bridging | markdownify }}
-</div>
 </div>
 
 


### PR DESCRIPTION
This PR fixes an issue reported by @brntbeer wherein the cheat sheet page for SVN Migrations was showing only one column instead of two.

Closes #640 