### PR TITLE
Redirect to Learning Lab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gem 'github-pages'
 gem 'html-proofer'
 gem 'rack-contrib', '~> 1.1.0'
 gem 'rake'
+
+gem "jekyll-redirect-from", "~> 0.12.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,8 +228,9 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   html-proofer
+  jekyll-redirect-from (~> 0.12.1)
   rack-contrib (~> 1.1.0)
   rake
 
 BUNDLED WITH
-   1.15.4
+   1.16.2

--- a/_config.yml
+++ b/_config.yml
@@ -93,3 +93,5 @@ defaults:
       path: ""
     values:
       lang: "en"
+      redirect_to:
+        - https://lab.github.com

--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-redirect-from
 
 exclude:
 - bin

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,4 +1,5 @@
 ---
+redirect_to: false
 ---
 
 @import "primer-core/index.scss";

--- a/resources/cheatsheets/index.html
+++ b/resources/cheatsheets/index.html
@@ -7,6 +7,7 @@ redirect_from:
   - /kit/downloads/git-github-cheat-sheet.pdf/
   - /kit/downloads/subversion-migration.pdf/
 breadcrumbColor: "bg-gray-light"
+redirect_to: false
 ---
 {% include light-hero.html %}
 {% include breadcrumbs.html %}


### PR DESCRIPTION
This PR adds redirects to every page (except for the Cheat Sheets page), redirecting the visitor to [GitHub Learning Lab](https://lab.github.com).

cc @crichID @dmleong 