### PR TITLE
Remove conflict markers in Bahasa Indonesia cheatsheet

### DIFF
--- a/downloads/id/github-git-cheat-sheet.md
+++ b/downloads/id/github-git-cheat-sheet.md
@@ -24,13 +24,8 @@ Distribusi Git untuk Linux dan sistem POSIX tersedia di situs resmi Git SCM.
 ### Git untuk Semua Sistem
 [git-scm.com](https://git-scm.com)
 
-<<<<<<< HEAD
-## Konfigurasikan Alat
-Konfigurasikan informasi pengguna untuk semua repositori lokal
-=======
 ## Konfigurasi Alat
 Konfigurasi informasi pengguna untuk semua repositori lokal
->>>>>>> 650865b3126909e88e5c603dc4e08e8290330e34
 
 ```$ git config --global user.name "[nama]"```
 
@@ -41,11 +36,7 @@ Mengatur nama yang ingin ditautkan pada transaksi _commit_ Anda
 Mengatur alamat surel yang ingin ditautkan pada transaksi _commit_ Anda
 
 ## Membuat Repositori
-<<<<<<< HEAD
-Mulai repositori baru atau ambil dari URL yang sudah ada
-=======
 Mulai repositori baru atau dapatkan satu dari URL yang sudah ada
->>>>>>> 650865b3126909e88e5c603dc4e08e8290330e34
 
 ```$ git init [nama-proyek]```
 
@@ -68,11 +59,7 @@ Tinjau suntingan dan buat sebuah transaksi _commit_
 
 ```$ git status```
 
-<<<<<<< HEAD
-Menampilkan semua berkas baru atau modifikasi yang siap didaftarkan dalam _commit_
-=======
 Daftar semua berkas baru atau modifikasi yang siap didaftarkan dalam _commit_
->>>>>>> 650865b3126909e88e5c603dc4e08e8290330e34
 
 ```$ git diff```
 
@@ -96,11 +83,7 @@ Batal merevisi berkas, namun tetap mempertahankan isinya
 Daftarkan perubahan berkas secara permanen di riwayat revisi
 
 ## Perubahan Berkelompok
-<<<<<<< HEAD
-Menyebutkan dan menggabungkan serangkain _commit_ yang telah selesai
-=======
 Menyebutkan serangkaian _commit_ dan menggabungkan upaya yang telah selesai
->>>>>>> 650865b3126909e88e5c603dc4e08e8290330e34
 
 ```$ git branch```
 
@@ -157,11 +140,7 @@ Sebuah berkas teks bernama `.gitignore` mengabaikan revisi berkas yang tidak dis
 
 ```$ git ls-files --others --ignored --exclude-standard```
 
-<<<<<<< HEAD
-Menampilkan semua berkas yang diabaikan dalam proyek tersebut
-=======
 Daftar semua berkas yang diabaikan dalam proyek tersebut
->>>>>>> 650865b3126909e88e5c603dc4e08e8290330e34
 
 ## Menyimpan Fragmen
 Menyimpan dan mengembalikan perubahan yang belum lengkap

--- a/downloads/id/github-git-cheat-sheet.md
+++ b/downloads/id/github-git-cheat-sheet.md
@@ -21,11 +21,11 @@ lanjutan.
 
 Distribusi Git untuk Linux dan sistem POSIX tersedia di situs resmi Git SCM.
 
-### Git untuk Semua Sistem
+### Sesawang Dokumentasi Git
 [git-scm.com](https://git-scm.com)
 
-## Konfigurasi Alat
-Konfigurasi informasi pengguna untuk semua repositori lokal
+## Konfigurasi Git
+Konfigurasi informasi git untuk pengguna dan system lokal 
 
 ```$ git config --global user.name "[nama]"```
 
@@ -36,7 +36,7 @@ Mengatur nama yang ingin ditautkan pada transaksi _commit_ Anda
 Mengatur alamat surel yang ingin ditautkan pada transaksi _commit_ Anda
 
 ## Membuat Repositori
-Mulai repositori baru atau dapatkan satu dari URL yang sudah ada
+Mulai repositori baru
 
 ```$ git init [nama-proyek]```
 

--- a/downloads/id/github-git-cheat-sheet.md
+++ b/downloads/id/github-git-cheat-sheet.md
@@ -21,7 +21,7 @@ lanjutan.
 
 Distribusi Git untuk Linux dan sistem POSIX tersedia di situs resmi Git SCM.
 
-### Sesawang Dokumentasi Git
+### Dokumentasi Lengkap Git
 [git-scm.com](https://git-scm.com)
 
 ## Konfigurasi Git


### PR DESCRIPTION
As I was cleaning up the cheatsheets, I discovered that the [Baha Indonesia cheatsheet](https://github.github.com/training-kit/downloads/id/github-git-cheat-sheet/) had some conflict markers that were committed. I've removed them all by accepting incoming changes.

@adhikasp @wisn @chocochino I see that you've committed to this file in the past, would you mind giving this some 👀?