### PR TITLE
Corrected the sed -i command in script/package shell script [#554]

### DIFF
--- a/script/package
+++ b/script/package
@@ -4,7 +4,7 @@ set -e
 
 version=$(git rev-parse --short HEAD)
 
-sed -i '' -e"s/google_tracking_id:.*/google_tracking_id:/" _config.yml
+sed -i'' -e"s/tracking_id\s*:.*/tracking_id:/" _config.yml
 script/build -d $(pwd)/_site
 (cd _site; tar -zcvf ../release-${version}.tgz .)
 ## we modify the config to remove the google tracker id, lets get it back.

--- a/script/package
+++ b/script/package
@@ -4,7 +4,7 @@ set -e
 
 version=$(git rev-parse --short HEAD)
 
-sed -i'' -e"s/tracking_id\s*:.*/tracking_id:/" _config.yml
+sed -i "" 's/tracking_id *:.*/tracking_id:/' _config.yml
 script/build -d $(pwd)/_site
 (cd _site; tar -zcvf ../release-${version}.tgz .)
 ## we modify the config to remove the google tracker id, lets get it back.


### PR DESCRIPTION
## Overview
In the training-kit README, a workflow is presented to create a local copy of the files to be served by a web-server. The first step of that workflow is to run `script/package`, but that step fails ...

This PR fixes two errors in the sed command inside script/package [ see comment by bazzaar in issue #554 ]

I subsequently ran through the corrected workflow on my local version of training-kit, and the web-served files are built and packaged successfully, and then display correctly in Firefox browser using the simple python web server.

### Questions
As the sed regex didn't match the text in the `_config.yml`, perhaps some change had been made to the `_config.yml` file previously, ... maybe the keywords are no longer as expected in that file? Just a thought ...

hope this helps
bazzaar