### PR TITLE
fixing typo in subtree cheatsheet

### DIFF
--- a/downloads/submodule-vs-subtree-cheat-sheet.md
+++ b/downloads/submodule-vs-subtree-cheat-sheet.md
@@ -197,7 +197,7 @@ Or while in the parent directory:
 {% capture subtree %}
 
 ### Subtree
-    git subtree push --prefix= example-submodule https://github.com/githubtraining/example-submodule master
+    git subtree push --prefix=example-submodule https://github.com/githubtraining/example-submodule master
 {% endcapture %}
 
 <div class="col-md-6">


### PR DESCRIPTION
## Overview
**TL;DR**

Fixing a typo in the `subtree` cheatsheet

### Review
@github/services-delivery 
