### PR TITLE
Revert "Bump rack from 2.0.6 to 2.0.8"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
-    rack (2.0.8)
+    rack (2.0.6)
     rack-contrib (1.1.0)
       rack (>= 0.9.1)
     rake (12.3.2)


### PR DESCRIPTION
Reverts github/training-kit#714

I noticed that the build was failing immediately after merging #714, and I am going to try to revert to see if this was the problem.

If the build does not pass, I will contact support to see when the build began to fail, so we can identify the breaking PR. 