### PR TITLE
Revert "Bump rubyzip from 1.2.2 to 2.0.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
     ruby-enum (0.7.2)
       i18n
     ruby_dep (1.5.0)
-    rubyzip (2.0.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.5)
     sass (3.7.3)
       sass-listen (~> 4.0.0)


### PR DESCRIPTION
Reverts github/training-kit#715 which broke the build