### PR TITLE
CONTRIBUTING: update 'Building and testing' instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,8 @@ When you are ready to test your changes, you will want to build the repository l
 
 To build the materials do the following:
 
-1. Run `script/setup`
-1. Run `sass --watch assets/_scss/main.scss:assets/css/main.css` to compile the SCSS
+1. Run `script/bootstrap` to install the dependencies
+1. Run `script/build` to build the site
 1. Run `script/server`
     - When successful, the script will initiate a local server at `http://127.0.0.1:4000/`.
 1. Simply paste that into your favorite web-browser and you will be ready to test


### PR DESCRIPTION
## Overview
**TL;DR**
<One to two sentence description of the issue you are encountering or trying to solve.>
The instructions for building the site locally were outdated. I updated them.


### Questions
I saw the README talks about `script/package` that doesn't exist anymore, but I didn't remove it as I couldn't figure the replacement procedure. I can update this branch with changes to the README if that's desired.

### Next Steps
- [ ] Update README

### Review

