### PR TITLE
Bring back script/package

### DIFF
--- a/script/package
+++ b/script/package
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+version=$(git rev-parse --short HEAD)
+
+sed -i "" 's/tracking_id *:.*/tracking_id:/' _config.yml
+script/build -d $(pwd)/_site
+(cd _site; tar -zcvf ../release-${version}.tgz .)
+## we modify the config to remove the google tracker id, lets get it back.
+git checkout -- _config.yml


### PR DESCRIPTION
## Overview
**TL;DR**
This pull request brings back a deleted `script/package`. It was deleted during a refactor, but we believe customers still occasionally use this to generate the training-kit to be used within their firewalls.

This closes #728 

### Review

Community reviews welcome, in addition to @github/services-programs 👀 
