### PR TITLE
Update github-git-cheat-sheet.md

### DIFF
--- a/downloads/github-git-cheat-sheet.md
+++ b/downloads/github-git-cheat-sheet.md
@@ -130,7 +130,7 @@ Outputs metadata and content changes of the specified commit
 
 Snapshots the file in preparation for versioning
 
-```$ git commit -m"[descriptive message]"```
+```$ git commit -m "[descriptive message]"```
 
 Records file snapshots permanently in version history
 


### PR DESCRIPTION
Fix terminal command for git commit

## Overview
**TL;DR**
Erroneous `git commit` command at the [git cheat sheet](https://github.github.com/training-kit/downloads/github-git-cheat-sheet/) page. Whitespace should be present between the `-m` flag and the commit message.

Closes #746 