### PR TITLE
specify jekyll version to workaround docker image bug

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     # Ruby-specific steps
     - name: Set up Ruby 2.6
@@ -26,9 +26,9 @@ jobs:
       run: |
         npm install
 
-    # Jekyll / GitHub-pages specific steps
+    # Jekyll-specific steps
     - name: Build the site in the jekyll/builder container
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+        jekyll/builder:4.0 /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"


### PR DESCRIPTION
## Overview
Checks failing due to issue with docker image.  workaround is to specify jekyll version.

https://github.com/envygeeks/jekyll-docker/issues/272