### PR TITLE
Add links to manuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,12 +65,12 @@ redirect_to: false
     <ul class="list-style-none">
       <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/training-manual/#/">GitHub for Developers Manual</a></li>
       <ul>
-        <li><a class="d-flex flex-items-center" href="https://github.com/githubtraining/training-manual"><span class="d-flex mr-2">{% octicon cloud-download %}</span> Source</a></li>
+        <li><a class="d-flex flex-items-center" href="https://github.com/githubtraining/training-manual"><span class="d-flex mr-2">{% octicon book %}</span> Source</a></li>
       </ul>
       <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/admin-training/#/">GitHub Administrator Manual</a></li>
       <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/saml-implementation-prep/#/">SAML Implementation Preparation</a></li>
       <ul>
-        <li><a class="d-flex flex-items-center" href="https://github.com/githubtraining/saml-implementation-prep"><span class="d-flex mr-2">{% octicon cloud-download %}</span> Source</a></li>
+        <li><a class="d-flex flex-items-center" href="https://github.com/githubtraining/saml-implementation-prep"><span class="d-flex mr-2">{% octicon book %}</span> Source</a></li>
       </ul>
       <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/innersource-theory/#/">InnerSource Theory</a></li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -63,15 +63,9 @@ redirect_to: false
     </ul>
     <h3 class="mt-2">Manuals</h3>
     <ul class="list-style-none">
-      <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/training-manual/#/">GitHub for Developers Manual</a></li>
-      <ul>
-        <li><a class="d-flex flex-items-center" href="https://github.com/githubtraining/training-manual"><span class="d-flex mr-2">{% octicon book %}</span> Source</a></li>
-      </ul>
+      <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/training-manual/#/">GitHub for Developers Manual</a><a class="d-flex flex-items-center" href="https://github.com/githubtraining/training-manual"><span class="d-flex mr-2">({% octicon book %}</span> Source)</a></li>
       <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/admin-training/#/">GitHub Administrator Manual</a></li>
-      <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/saml-implementation-prep/#/">SAML Implementation Preparation</a></li>
-      <ul>
-        <li><a class="d-flex flex-items-center" href="https://github.com/githubtraining/saml-implementation-prep"><span class="d-flex mr-2">{% octicon book %}</span> Source</a></li>
-      </ul>
+      <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/saml-implementation-prep/#/">SAML Implementation Preparation</a><a class="d-flex flex-items-center" href="https://github.com/githubtraining/saml-implementation-prep"><span class="d-flex mr-2">({% octicon book %}</span> Source)</a></li>
       <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/innersource-theory/#/">InnerSource Theory</a></li>
     </ul>
   </div>

--- a/index.html
+++ b/index.html
@@ -61,5 +61,18 @@ redirect_to: false
     <ul class="list-style-none">
       <li><a class="d-flex flex-items-center" href="{{ site.baseurl }}/downloads/submodule-vs-subtree-cheat-sheet/"><span class="d-flex mr-2">{% octicon cloud-download %}</span> English</a></li>
     </ul>
+    <h3 class="mt-2">Manuals</h3>
+    <ul class="list-style-none">
+      <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/training-manual/#/">GitHub for Developers Manual</a></li>
+      <ul>
+        <li><a class="d-flex flex-items-center" href="https://github.com/githubtraining/training-manual"><span class="d-flex mr-2">{% octicon cloud-download %}</span> Source</a></li>
+      </ul>
+      <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/admin-training/#/">GitHub Administrator Manual</a></li>
+      <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/saml-implementation-prep/#/">SAML Implementation Preparation</a></li>
+      <ul>
+        <li><a class="d-flex flex-items-center" href="https://github.com/githubtraining/saml-implementation-prep"><span class="d-flex mr-2">{% octicon cloud-download %}</span> Source</a></li>
+      </ul>
+      <li><a class="d-flex flex-items-center" href="https://githubtraining.github.io/innersource-theory/#/">InnerSource Theory</a></li>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
## Overview
**TL;DR**

We are open sourcing the training manuals. This PR adds links to those manuals, so that the `training-kit` landing page is a resource for finding other learning content in addition to cheat sheets.

### Questions
<If relevant, write a list of questions that you would like to discuss related to the changes that you have made.>
N/A

### Next Steps
<If incomplete, create a task list of items that are still being worked on within the Pull Request.>

As we move the training manual for developers into the GitHub org, we will need to update the link here. 

### Review
<If complete, or ready for :eyes:, use @mentions for quick questions, specific feedback, and progress updates.>

cc @parkerbxyz @github/ps-programs for awareness and review 👀 