### PR TITLE
Change all instances of "master" to "main"

### DIFF
--- a/git-guides/git-clone.md
+++ b/git-guides/git-clone.md
@@ -18,7 +18,7 @@ The ability to work with the entire repository means that all developers can wor
 -  later use `git push` to share your branch with the remote repository
 - open a pull request to compare the changes with your collaborators
 - test and deploy as needed from the branch
-- merge into the `master` branch.
+- merge into the `main` branch.
 
 ## How to Use `git clone`
 
@@ -44,7 +44,7 @@ The most common usage of cloning is to simply clone a repository. This is only d
 
 But, maybe for some reason you would like to _only_ get a remote tracking branch for one specific branch, or clone one branch which _isn't_ the default branch. Both of these things happen when you use `--single-branch` with `git clone`.
 
-This will create a clone that only has commits included in the current line of history. This means no other branches will be cloned. You can specify a certain branch to clone, but the default branch, usually `master`, will be selected by default.
+This will create a clone that only has commits included in the current line of history. This means no other branches will be cloned. You can specify a certain branch to clone, but the default branch, usually `main`, will be selected by default.
 
 To clone one specific branch, use:
 

--- a/git-guides/git-overview.md
+++ b/git-guides/git-overview.md
@@ -36,7 +36,7 @@ Without sharing the code through branches, this would never be possible.
 
 ### Ease of roll back
 
-If you make a mistake, it's OK! Commits are immutable, meaning they can't be changed. (*Note: You _can_ change history, but it will create new replacement commits instead of editing the existing commits. More on that later!*) This means that if you do make a mistake, even on an important branch like master, it's _OK_. **You can easily revert that change, or roll back the branch pointer to the commit where everything was fine.**
+If you make a mistake, it's OK! Commits are immutable, meaning they can't be changed. (*Note: You _can_ change history, but it will create new replacement commits instead of editing the existing commits. More on that later!*) This means that if you do make a mistake, even on an important branch like `main`, it's _OK_. **You can easily revert that change, or roll back the branch pointer to the commit where everything was fine.**
 
 The benefits of this can't be overstated. Not only does it create a safer environment for the project and code, but it fosters a development environment where developers can be braver, trusting that Git has their back.
 
@@ -48,7 +48,7 @@ There are _many_ ways to use Git, which doesn't necessarily make it easier! But,
 
 ### Create a branch
 
-The main branch is usually called `master`. We want to work on _another_ branch, so we can make a pull request and make changes safely. To get started, create a branch off of `master`. Name it however you'd like - but we recommend naming branches based on the function or feature that will be the focus of this branch. One person may have several branches, and one branch may have several people collaborate on it - branches are for a purpose, not a person. Wherever you currently "are" (wherever HEAD is pointing, or whatever branch you're currently "checked out" to) will be the parent of the branch you create. That means you can create branches from other branches, tags, or any commit! But, the most typical workflow is to create a branch from `master` - which represents the most current production code.
+The main branch is usually called `main`. We want to work on _another_ branch, so we can make a pull request and make changes safely. To get started, create a branch off of `main`. Name it however you'd like - but we recommend naming branches based on the function or feature that will be the focus of this branch. One person may have several branches, and one branch may have several people collaborate on it - branches are for a purpose, not a person. Wherever you currently "are" (wherever HEAD is pointing, or whatever branch you're currently "checked out" to) will be the parent of the branch you create. That means you can create branches from other branches, tags, or any commit! But, the most typical workflow is to create a branch from `main` - which represents the most current production code.
 
 ### Make change (and make a commit)
 
@@ -70,7 +70,7 @@ Sometimes, if there has been a new commit on the branch on the _remote_, you may
 
 ### Open a pull request
 
-Pushing a branch, or new commits, to a remote repository is enough if a pull request already exists, but if it's the first time you're pushing that branch, you should open a new pull request. A pull request is a comparison of two branches - typically `master`, or the branch that the feature branch was created from, and the feature branch. This way, like branches, pull requests are scoped around a specific function or addition of work, rather than the person making the changes or amount of time the changes will take.
+Pushing a branch, or new commits, to a remote repository is enough if a pull request already exists, but if it's the first time you're pushing that branch, you should open a new pull request. A pull request is a comparison of two branches - typically `main`, or the branch that the feature branch was created from, and the feature branch. This way, like branches, pull requests are scoped around a specific function or addition of work, rather than the person making the changes or amount of time the changes will take.
 
 Pull requests are the powerhouse of GitHub. Integrated tests can automatically run on pull requests, giving you immediate feedback on your code. Peers can give detailed code reviews, letting you know if there are changes to make, or if it's ready to go.
 
@@ -82,9 +82,9 @@ Once the pull request is open, then the real fun starts. It's important to recog
 
 It's very likely that you will want to make more changes to your work. That's great! To do that, make more commits on the same branch. Once the new commits are present on the remote, the pull request will update and show the most recent version of your work.
 
-### Merge into master
+### Merge into `main`
 
-Once you and your team decide that the pull request looks good, you can merge it. By merging, you integrate the feature branch into the other branch (most typically the `master` branch). Then, `master` will be updated with your changes, and your pull request will be closed. Don't forget to delete your branch! You won't need it anymore. Remember, branches are lightweight and cheap, and you should create a new one when you need it based on the most recent commit on the `master` branch.
+Once you and your team decide that the pull request looks good, you can merge it. By merging, you integrate the feature branch into the other branch (most typically the `main` branch). Then, `main` will be updated with your changes, and your pull request will be closed. Don't forget to delete your branch! You won't need it anymore. Remember, branches are lightweight and cheap, and you should create a new one when you need it based on the most recent commit on the `main` branch.
 
 If you choose not to merge the pull request, you can also close pull requests with unmerged changes.
 

--- a/git-guides/git-pull.md
+++ b/git-guides/git-pull.md
@@ -14,7 +14,7 @@ git pull
 
 ### `git pull` and `git fetch`
 
-`git pull`, a combination of `git fetch` + `git merge`, updates some parts of your local repository with changes from the remote repository. To understand what is and isn't affected by `git pull`, you need to first understand the concept of remote tracking branches. When you clone a repository, you clone one working branch, `master`, and all of the remote tracking branches. `git fetch` updates the remote tracking branches. `git merge` will update your current branch with any new commits on the remote tracking branch.
+`git pull`, a combination of `git fetch` + `git merge`, updates some parts of your local repository with changes from the remote repository. To understand what is and isn't affected by `git pull`, you need to first understand the concept of remote tracking branches. When you clone a repository, you clone one working branch, `main`, and all of the remote tracking branches. `git fetch` updates the remote tracking branches. `git merge` will update your current branch with any new commits on the remote tracking branch.
 
 `git pull` is the most common way to update your repository.
 
@@ -39,17 +39,17 @@ You can see all of the many options with `git pull` in [git-scm's documentation]
 
 ### Working on a Branch
 
-If you're already working on a branch, it is a good idea to run `git pull` before starting work and introducing new commits. Even if you take a small break from development, there's a chance that one of your collaborators has made changes to your branch. This change could even come from updating your branch with new changes from `master`.
+If you're already working on a branch, it is a good idea to run `git pull` before starting work and introducing new commits. Even if you take a small break from development, there's a chance that one of your collaborators has made changes to your branch. This change could even come from updating your branch with new changes from `main`.
 
 It is always a good idea to run `git status` - especially before `git pull`. Changes that are not committed can be overwritten during a `git pull`. Or, they can block the `git merge` portion of the `git pull` from executing. If you have files that are changed, but not committed, and the changes on the remote also change those same parts of the same file, Git must make a choice. Since they are not committed changes, there is no possibility for a merge conflict. Git will either overwrite the changes in your working or staging directories, or the `merge` will not complete, and you will not be able to include any of the updates from the remote.
 
 If this happens, use `git status` to identify what changes are causing the problem. Either delete or commit those changes, then `git pull` or `git merge` again.
 
-### Keep `master` up to date
+### Keep `main` up to date
 
-Keeping the `master` branch up to date is generally a good idea.
+Keeping the `main` branch up to date is generally a good idea.
 
-For example, let's say you have cloned a repository. After you clone, someone merges a branch into master. Then, you'd like to create a new branch to do some work. If you create your branch off of `master` _before_ operating `git pull`, your branch will not have the most recent changes. You could accidentally introduce a conflict, or duplicate changes. By running `git pull` before you create a branch, you can be sure that you will be working with the most recent information.
+For example, let's say you have cloned a repository. After you clone, someone merges a branch into main. Then, you'd like to create a new branch to do some work. If you create your branch off of `main` _before_ operating `git pull`, your branch will not have the most recent changes. You could accidentally introduce a conflict, or duplicate changes. By running `git pull` before you create a branch, you can be sure that you will be working with the most recent information.
 
 ### Undo A `git pull`
 
@@ -64,12 +64,12 @@ Run `git reflog` and search for the commit that you would like to return to. The
 If you have made commits locally that you regret, you may want your local branch to match the remote branch without saving any of your work. This can be done using `git reset`. First, make sure you have the most recent copy of that remote tracking branch by fetching.
 
 `git fetch <remote> <branch>`
-ex: `git fetch origin master`
+ex: `git fetch origin main`
 
 Then, use `git reset --hard` to move the HEAD pointer and the current branch pointer to the most recent commit as it exists on that remote tracking branch.
 
 `git reset --hard <remote>/<branch>`
-ex: `git reset --hard origin/master`
+ex: `git reset --hard origin/main`
 
 > _Note: You can find the remotes with `git remote -v`, and see all available remote tracking branches with `git branch --all`.
 

--- a/git-guides/git-push.md
+++ b/git-guides/git-push.md
@@ -10,7 +10,7 @@ git push
 
 `git push` updates the remote branch with local commits. It is one of the four commands in Git that prompts interaction with the remote repository. You can also think of `git push` as _update_ or _publish_. 
 
-By default, `git push` only updates the corresponding branch on the remote. So, if you are checked out to the `master` branch when you execute `git push`, then only the `master` branch will be updated. It's always a good idea to use `git status` to see what branch you are on before pushing to the remote.
+By default, `git push` only updates the corresponding branch on the remote. So, if you are checked out to the `main` branch when you execute `git push`, then only the `main` branch will be updated. It's always a good idea to use `git status` to see what branch you are on before pushing to the remote.
 
 ## How to Use `git push`
 
@@ -33,7 +33,7 @@ If you are trying to `git push` but are running into problems, there are a few c
 
 ### Check your branch
 
-Check what branch you are currently on with `git status`. If you are working on a protected branch, like `master`, you may be unable to push commits directly to the remote. If this happens to you, it's OK! You can fix this a few ways.
+Check what branch you are currently on with `git status`. If you are working on a protected branch, like `main`, you may be unable to push commits directly to the remote. If this happens to you, it's OK! You can fix this a few ways.
 
 #### Work was not yet on any branch
 
@@ -43,7 +43,7 @@ Check what branch you are currently on with `git status`. If you are working on 
 #### Accidentally committed to the wrong branch
 
 1. Checkout to the branch that you intended to commit to: `git checkout [branchname]`
-2. Merge the commits from the branch that you _did_ accidentally commit to: `git merge [master]`
+2. Merge the commits from the branch that you _did_ accidentally commit to: `git merge [main]`
 3. Push your changes to the remote: `git push`
 4. Fix the other branch by checking out to that branch, finding what commit it _should_ be pointed to, and using `git reset --hard` to correct the branch pointer
 

--- a/git-guides/git-status.md
+++ b/git-guides/git-status.md
@@ -35,4 +35,4 @@ You can see all of the options with `git status` in [git-scm's documentation](ht
 - `git remote -v`: Show the associated remote repositories and their stored name, like `origin`.
 - `git remote add origin <url>`: Add a remote so you can collaborate with others on a newly initialized repository.
 - `git push`: Uploads all local branch commits to the remote.
-- `git push -u origin master`: When pushing a branch for the first time, this type of push will configure the relationship between the remote and your local repository so that you can use `git pull` and `git push` with no additional options in the future.
+- `git push -u origin main`: When pushing a branch for the first time, this type of push will configure the relationship between the remote and your local repository so that you can use `git pull` and `git push` with no additional options in the future.


### PR DESCRIPTION
Title. Default default branch name was changed to master [in October](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/). This PR just updates pages to account for the rename.