### PR TITLE
Exclude package.json and package-lock.json from production

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,6 +69,8 @@ exclude:
 - README.md
 - script
 - vendor
+- package.json
+- package-lock.json
 
 collections:
   modules:


### PR DESCRIPTION
This PR excludes `package.json` and `package-lock.json` from being deployed to production.