### PR TITLE
fix inflection of proper names in polish

### DIFF
--- a/downloads/pl/github-git-cheat-sheet.md
+++ b/downloads/pl/github-git-cheat-sheet.md
@@ -2,18 +2,18 @@
 layout: cheat-sheet
 redirect_to: false
 title: GitHub Git Ściąga
-byline: Git to otwartoźródłowy rozproszony system kontroli wersji który umożliwia działanie GitHub'a na twoim laptopie lub komputerze stacjonarnym. Ta ściąga podsumowuje najczęściej używane komendy wiersza poleceń Git'a w celu szybkiego dostępu.
+byline: Git to otwartoźródłowy rozproszony system kontroli wersji który umożliwia działanie GitHuba na twoim laptopie lub komputerze stacjonarnym. Ta ściąga podsumowuje najczęściej używane komendy wiersza poleceń Gita w celu szybkiego dostępu.
 leadingpath: ../../../
 ---
 
 {% capture colOne %}
-## Instalacja Git'a
-GitHub dostarcza klienta dla komputerów który zawiera interfejs graficzny dla najbardziej powszechnych akcji w repozytorium i automatycznie aktualizuje edycje Git'a w lini komend dla zaawansowanych scenariuszy.
+## Instalacja Gita
+GitHub dostarcza klienta dla komputerów który zawiera interfejs graficzny dla najbardziej powszechnych akcji w repozytorium i automatycznie aktualizuje edycje Gita w lini komend dla zaawansowanych scenariuszy.
 
 ### GitHub Desktop
 [desktop.github.com](https://desktop.github.com)
 
-Dystrybucje Git'a dla systemu Linux i POSIX dostępne są na oficjalnej stronie Git SCM.
+Dystrybucje Gita dla systemu Linux i POSIX dostępne są na oficjalnej stronie Git SCM.
 
 ### Git dla wszystkich platform
 [git-scm.com](https://git-scm.com)
@@ -234,7 +234,7 @@ Pobiera całą historię ze zdalnego repozytorium
 
 ```$ git push [remote] [gałąź]```
 
-Przesyła lokalną gałąź do GitHub'a
+Przesyła lokalną gałąź do GitHuba
 
 
 ```$ git pull```


### PR DESCRIPTION
## Overview
**TL;DR**
This fixes inflection errors in proper names of Git and GitHub.

Quite many polish nouns have `-a` suffix in genitive case.
When inflecting foreign words, we sometimes put an apostrophe before the suffix, but this usually works if the base word ends with a vowel / silent letter. People may get confused about how they should inflect words that end for example with `e`, like `Google / Google'a / Googla`, especially that there's no official guide for every case.

`https://sjp.pwn.pl/poradnia/` is a website where people can ask questions about the polish language, and the people who answer the questions there are usually considered authorities when it comes to the language.
https://sjp.pwn.pl/poradnia/haslo/Apostrof-i-lacznik-w-odmianie-wyrazow;18398.html
Here's a question regarding using apostrophes and dashes before inflection prefixes.
I know that the polish text won't help you much with understanding this, but I'm leaving it here in case someone wants to know the reasoning.

In the cases of `Git` and `GitHub` there's no doubt - *we don't put the apostrophe before the prefix*.
We pronounce the `t` and `b`, thus we write `Gita`, `GitHuba`.