### PR TITLE
'git clone' guide: <pathspec> is optional for '--recurse-submodules'

### DIFF
--- a/git-guides/git-clone.md
+++ b/git-guides/git-clone.md
@@ -28,7 +28,7 @@ The ability to work with the entire repository means that all developers can wor
 * `git clone --mirror`: Clone a repository but without the ability to edit any of the files. This includes the refs or branches. You may want to use this if you are trying to create a secondary copy of a repository on a separate remote and you want to match all of the branches. This may occur during configuration using a new remote for your Git hosting, or when using Git during automated testing.
 * `git clone --single-branch`: Clone only a single branch
 * `git clone --sparse`: Instead of populating the working directory with all of the files in the current commit recursively, only populate the files present in the root directory. This could help with performance when cloning large repositories with many directories and sub-directories.
-*   `git clone --recurse-submodules[=<pathspec]`: After the clone is created, initialize and clone submodules within based on the provided pathspec. This may be a good option if you are cloning a repository that you know to have submodules, and you will be working with those submodules as dependencies in your local development.
+*   `git clone --recurse-submodules[=<pathspec]`: After the clone is created, initialize and clone submodules within based on the provided pathspec (or all submodules if no pathspec is given). This may be a good option if you are cloning a repository that you know to have submodules, and you will be working with those submodules as dependencies in your local development.
 
 You can see all of the many options with `git clone` in [git-scm's documentation](https://git-scm.com/docs/git-clone).
 


### PR DESCRIPTION
## Overview
**TL;DR**
<One to two sentence description of the issue you are encountering or trying to solve.>

Add a mention that the `--recurse-submodules` flag to `git clone` does not need a pathspec, and also add a missing backtick.
