### PR TITLE
Revise Git installation instructions for Mac

### DIFF
--- a/git-guides/install-git.md
+++ b/git-guides/install-git.md
@@ -44,13 +44,9 @@ Note: You can perform actions like, you can search for and clone a repository fr
 
 Most versions of MacOS will already have `Git` installed, and you can activate it through the terminal with `git version`. However, if you don't have Git installed for whatever reason, you can install the latest version of Git using one of several popular methods as listed below:
 
-### Install Git From an Installer
+### Install Git using Git-Scm.com Help
 
-1. Navigate to the latest [macOS Git Installer](https://sourceforge.net/projects/git-osx-installer/files/git-2.23.0-intel-universal-mavericks.dmg/download?use_mirror=autoselect) and download the latest version.
-2. Once the installer has started, follow the instructions as provided until the installation is complete.
-3. Open the command prompt "terminal" and type `git version` to verify Git was installed.
-
-Note: [`git-scm`](https://git-scm.com/download/mac) is a popular and recommended resource for downloading Git on a Mac. The advantage of downloading Git from `git-scm` is that your download automatically starts with the latest version of Git. The download source is the same [macOS Git Installer](https://sourceforge.net/projects/git-osx-installer/files/git-2.23.0-intel-universal-mavericks.dmg/download?use_mirror=autoselect) as referenced in the steps above.
+[`git-scm`](https://git-scm.com/download/mac) is a popular and recommended resource for downloading Git on a Mac. The advantage of downloading Git from `git-scm` is that your download automatically starts with the latest version of Git. The download source is the same [macOS Git Installer](https://sourceforge.net/projects/git-osx-installer/files/git-2.23.0-intel-universal-mavericks.dmg/download?use_mirror=autoselect) as referenced in the steps above.
 
 ### Install Git from Homebrew
 


### PR DESCRIPTION
Updated the installation instructions for Git on Mac to recommend using Git-Scm.com and removed directions linking to the abandoned Tim Charper build on Sourceforge.

## Overview

The Tim Charper macOS build on Sourceforge has been marked as abandoned, and is also no longer linked to on the page [https://git-scm.com/install/mac](https://git-scm.com/install/mac)

The source forge abandoned status can be seen here: https://sourceforge.net/projects/git-osx-installer/


## Next steps

The text surrounding this change could also be improved, but I suggest we do this one step at a time.

